### PR TITLE
QUA-1587: Remove catalog operation option from the CLI

### DIFF
--- a/qualytics/cli/datastores.py
+++ b/qualytics/cli/datastores.py
@@ -144,7 +144,7 @@ def datastores_create(
             enrichment_source_record_limit=enrichment_source_record_limit,
             enrichment_remediation_strategy=enrichment_remediation_strategy,
             high_count_rollup_threshold=high_count_rollup_threshold,
-            trigger_catalog=trigger_sync,
+            trigger_sync=trigger_sync,
             database=database,
             schema=schema,
         )

--- a/qualytics/services/datastores.py
+++ b/qualytics/services/datastores.py
@@ -66,7 +66,7 @@ def build_create_datastore_payload(
     enrichment_source_record_limit: int | None = None,
     enrichment_remediation_strategy: str = "none",
     high_count_rollup_threshold: int | None = None,
-    trigger_catalog: bool = True,
+    trigger_sync: bool = True,
     database: str,
     schema: str,
 ) -> dict:
@@ -76,7 +76,7 @@ def build_create_datastore_payload(
         "connection_id": int(connection_id),
         "enrichment_only": enrichment_only,
         "enrichment_remediation_strategy": enrichment_remediation_strategy,
-        "trigger_catalog": trigger_catalog,
+        "trigger_sync": trigger_sync,
         "tags": tags,
         "teams": teams,
         "database": database,

--- a/qualytics/services/export_import.py
+++ b/qualytics/services/export_import.py
@@ -627,6 +627,14 @@ def _import_datastore(
             result["failed"] += 1
             return result
 
+        if "trigger_catalog" in data:
+            result["errors"].append(
+                f"Skipped {ds_file}: 'trigger_catalog' is no longer supported; "
+                "use 'trigger_sync'"
+            )
+            result["failed"] += 1
+            return result
+
         ds_name = data["name"]
 
         # Resolve connection_name → connection_id
@@ -666,8 +674,8 @@ def _import_datastore(
             # Fetch full datastore (list endpoint returns lightweight objects
             # missing the connection object needed for proper merging)
             full_existing = get_datastore(client, ds_id)
-            # Don't send trigger_catalog on update
-            data.pop("trigger_catalog", None)
+            # trigger_sync applies only when creating a datastore.
+            data.pop("trigger_sync", None)
             # PUT requires full payload — merge import data on top of current state
             from .datastores import flatten_datastore_for_put
 

--- a/tests/test_datastores.py
+++ b/tests/test_datastores.py
@@ -277,6 +277,18 @@ class TestBuildCreateDatastorePayload:
         assert payload["connection_id"] == 5
         assert payload["database"] == "mydb"
         assert payload["schema"] == "public"
+        assert payload["trigger_sync"] is True
+        assert "trigger_catalog" not in payload
+
+    def test_can_disable_initial_sync(self):
+        payload = build_create_datastore_payload(
+            name="ds1",
+            connection_id=5,
+            database="mydb",
+            schema="public",
+            trigger_sync=False,
+        )
+        assert payload["trigger_sync"] is False
 
 
 class TestBuildUpdateDatastorePayload:
@@ -342,6 +354,9 @@ class TestDatastoresCreateCLI:
         assert result.exit_code == 0
         assert "created successfully" in result.output
         mock_create.assert_called_once()
+        payload = mock_create.call_args.args[1]
+        assert payload["trigger_sync"] is True
+        assert "trigger_catalog" not in payload
 
     @patch("qualytics.cli.datastores.create_datastore")
     @patch("qualytics.cli.datastores.get_connection_by")

--- a/tests/test_export_import.py
+++ b/tests/test_export_import.py
@@ -466,6 +466,25 @@ class TestImportConnections:
 
 
 class TestImportDatastore:
+    def test_rejects_legacy_trigger_catalog(self, mock_client, tmp_path):
+        ds_dir = tmp_path / "my_ds"
+        ds_dir.mkdir()
+        ds_file = ds_dir / "_datastore.yaml"
+        ds_file.write_text(
+            yaml.safe_dump(
+                {
+                    "name": "my-ds",
+                    "connection_name": "prod-pg",
+                    "trigger_catalog": True,
+                }
+            )
+        )
+
+        result = _import_datastore(mock_client, ds_dir)
+
+        assert result["failed"] == 1
+        assert "'trigger_catalog' is no longer supported" in result["errors"][0]
+
     def test_creates_new_datastore(self, mock_client, tmp_path):
         ds_dir = tmp_path / "my_ds"
         ds_dir.mkdir()
@@ -476,6 +495,7 @@ class TestImportDatastore:
                     "database": "db",
                     "schema": "public",
                     "connection_name": "prod-pg",
+                    "trigger_sync": True,
                 }
             )
         )
@@ -499,6 +519,9 @@ class TestImportDatastore:
         assert result["created"] == 1
         assert result["datastore_id"] == 10
         mock_create.assert_called_once()
+        payload = mock_create.call_args.args[1]
+        assert payload["trigger_sync"] is True
+        assert "trigger_catalog" not in payload
 
     def test_updates_existing_datastore(self, mock_client, tmp_path):
         ds_dir = tmp_path / "my_ds"
@@ -510,6 +533,7 @@ class TestImportDatastore:
                     "database": "db",
                     "schema": "public",
                     "connection_name": "prod-pg",
+                    "trigger_sync": True,
                 }
             )
         )
@@ -532,6 +556,8 @@ class TestImportDatastore:
         assert result["updated"] == 1
         assert result["datastore_id"] == 10
         mock_update.assert_called_once()
+        payload = mock_update.call_args.args[2]
+        assert "trigger_sync" not in payload
 
     def test_connection_not_found(self, mock_client, tmp_path):
         ds_dir = tmp_path / "my_ds"


### PR DESCRIPTION
### Linear

Ref QUA-1587

### Overview

Removes the final catalog-operation API option from the Qualytics CLI. The public CLI already exposes `operations sync` and `--trigger-sync`; this PR makes datastore creation send the matching `trigger_sync` field instead of translating it back to the removed `trigger_catalog` contract.

### Key changes

- Renames the datastore payload builder argument from `trigger_catalog` to `trigger_sync` and emits only `trigger_sync`.
- Keeps the existing `--trigger-sync/--no-trigger-sync` user-facing flag wired directly to the new API field.
- Rejects config imports containing legacy `trigger_catalog` with a clear migration message.
- Removes `trigger_sync` from datastore update payloads because it is create-only.

### Breaking change

Python callers of `build_create_datastore_payload()` must use `trigger_sync`. Legacy config files must replace `trigger_catalog` with `trigger_sync`.

### Deployment

Release this CLI with or after the coordinated controlplane cutover. Older controlplane versions do not implement the new datastore-create field correctly.

### Related PRs

- Controlplane: https://github.com/Qualytics/controlplane/pull/2669
- Dataplane: https://github.com/Qualytics/dataplane/pull/1842
- Frontend: https://github.com/Qualytics/frontend/pull/2213

### Validation

- Full pytest suite — passed
- Focused datastore and config import tests — passed
- Ruff check and format — passed
- Pre-commit hooks — passed
