### PR TITLE
feat: dbt manifest migration (`qualytics dbt plan` / `import`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ qualytics config import --input ./qualytics-config --dry-run
 | `datastores` | Create and manage datastores |
 | `containers` | Create and manage computed containers |
 | `checks` | Create and manage quality checks |
+| `dbt` | Migrate dbt tests to Qualytics quality checks |
 | `anomalies` | View and manage detected anomalies |
 | `operations` | Trigger sync, profile, and scan operations |
 | `config` | Export and import configuration as code |
@@ -70,6 +71,7 @@ Run `qualytics <command> --help` for full details on any command.
 | [Quality Checks](docs/checks.md) | Creating checks from YAML (single and bulk) |
 | [Operations](docs/operations.md) | Sync, profile, scan workflows |
 | [Export/Import](docs/export-import.md) | Config-as-code: export, import, CI/CD promotion |
+| [dbt Migration](docs/dbt.md) | Converting a dbt manifest into quality checks |
 | [Anomalies](docs/anomalies.md) | Viewing and managing anomalies |
 | [Computed Fields](docs/computed-fields.md) | User-defined computed fields in export/import |
 | [Computed Tables](docs/computed-tables.md) | Bulk import of computed tables from Excel/CSV |

--- a/docs/dbt.md
+++ b/docs/dbt.md
@@ -60,6 +60,7 @@ qualytics dbt import --manifest target/manifest.json --datastore-id 42 \
 | `--container-case` | Force container name case: `upper` or `lower` |
 | `--preserve-status` | Omit `status` so re-imports keep what was set in the product |
 | `--status` | Force every check to `Active` or `Draft`, overriding the tier default |
+| `--no-validate-fields` | Skip checking field names against the catalogue |
 | `--emit-yaml` | Also write the converted checks to a directory |
 
 `--status` and `--preserve-status` are mutually exclusive.
@@ -142,6 +143,28 @@ By default `import` sets `status` from the tier, which means a re-import resets 
 
 - **Config-as-code** — treat the YAML as the source of truth. Activate by editing `status` in the emitted file, not in the UI.
 - **`--preserve-status`** — omit `status` entirely so the importer keeps whatever the check currently has.
+
+## Field validation
+
+Field names are checked against the container's catalogue before import, and this is on by default.
+
+It exists because the two halves of a check are validated very differently: the importer resolves container names to IDs and errors when one is missing, but passes `fields` straight through. A field name that doesn't exist in the warehouse therefore creates a check that never evaluates, with no error anywhere.
+
+Because the catalogue is ground truth, validation also **fixes casing** rather than guessing at it:
+
+```
+Corrected 3 field name(s) to catalogue casing: stg_orders.order_id → ORDER_ID, …
+```
+
+dbt writes `order_id`, Snowflake catalogues `ORDER_ID`. There is no `--field-case` flag because the right answer is knowable, not a preference.
+
+A field that matches nothing withholds its check and reports why:
+
+```
+Field(s) not found in container 'stg_orders': shipped_at
+```
+
+Only containers the checks actually reference are fetched. A container that can't be read, or one the importer will reject anyway, is skipped and its checks pass through unvalidated — a lookup problem must not block the import. `--no-validate-fields` turns the whole step off.
 
 ## Container name resolution
 

--- a/docs/dbt.md
+++ b/docs/dbt.md
@@ -101,6 +101,28 @@ A few dbt tests assert two things at once, and split:
 
 Each half gets its own check with the UID suffixed by its rule type (`…__minlength`, `…__maxlength`), so both upsert independently. A one-sided dbt test emits only the half it specifies — `min_value` alone produces just a `minLength`. Because of this, `plan` reports check count and dbt test count separately when they differ.
 
+## What carries across
+
+**`where` becomes `filter`.** A dbt test scoped with `config.where` produces a check with the same SQL predicate in `filter`, which every Qualytics rule type supports. This is a correctness mapping, not a nicety — dropping it would run the check against exactly the rows dbt was told to exclude.
+
+**Everything else lands in metadata.** dbt facts with no direct Qualytics field are recorded on the check rather than discarded, so a reviewer completing a Draft never has to reopen the dbt project:
+
+```yaml
+filter: status != 'deleted'          # from config.where
+additional_metadata:
+  _qualytics_check_uid: dbt__test_jaffle_not_null_proportion_stg_orders_amount_abc
+  dbt_unique_id: test.jaffle.not_null_proportion_stg_orders_amount.abc
+  dbt_test: dbt_utils.not_null_proportion
+  dbt_package: jaffle
+  dbt_severity: warn                 # only when it differs from dbt's default
+  dbt_tags: [nightly]
+  dbt_limit: 500
+  dbt_kwargs: {at_least: 0.95}       # every kwarg the mapping did not consume
+  dbt_compiled_sql: ...              # singular tests
+```
+
+`dbt_kwargs` is the important one: when a rule maps but its parameters don't, the original thresholds stay visible on the check itself. `additional_metadata` is typed `dict[str, Any]` server-side, so lists and nested values are preserved rather than stringified.
+
 ## Idempotency
 
 Each check's `_qualytics_check_uid` is derived from the dbt node's `unique_id`:

--- a/docs/dbt.md
+++ b/docs/dbt.md
@@ -59,7 +59,10 @@ qualytics dbt import --manifest target/manifest.json --datastore-id 42 \
 | `--container-map` | Override a container name: `model=container` (repeatable) |
 | `--container-case` | Force container name case: `upper` or `lower` |
 | `--preserve-status` | Omit `status` so re-imports keep what was set in the product |
+| `--status` | Force every check to `Active` or `Draft`, overriding the tier default |
 | `--emit-yaml` | Also write the converted checks to a directory |
+
+`--status` and `--preserve-status` are mutually exclusive.
 
 ## Migration tiers
 
@@ -72,6 +75,20 @@ Every dbt test converts. Tiers grade **effort**, not feasibility.
 | `manual` | Custom SQL — the expression must be authored | `Draft` |
 
 Nothing is skipped. An unrecognized generic test or a singular SQL test still produces a check, as a `satisfiesExpression` in `Draft` with the dbt source recorded in `additional_metadata`, so a reviewer adapts it rather than going back to the dbt project to find it.
+
+### Status is yours to set
+
+The tier → status mapping above is the **default, not a policy**. `--status` overrides it wholesale:
+
+```bash
+# review everything before anything fires
+qualytics dbt import -m target/manifest.json --datastore-id 42 --status Draft
+
+# activate everything, including checks that need editing
+qualytics dbt import -m target/manifest.json --datastore-id 42 --status Active
+```
+
+The default exists because `manual` checks carry an empty `expression`, and several `normalize` rules (`volumetric`, `freshness`, `distinctCount`, `metric`) are created with empty properties — dbt's kwargs don't carry a window, interval, or bound. Those checks are unlikely to evaluate meaningfully until edited. `--status Active` prints how many fall into that group and then does what you asked.
 
 ### Tests that become two checks
 

--- a/docs/dbt.md
+++ b/docs/dbt.md
@@ -185,4 +185,4 @@ Native dbt, `dbt_utils`, and `dbt_expectations` generic tests are mapped in `qua
 - run: qualytics dbt import --manifest target/manifest.json --datastore-id ${{ vars.DS_ID }} --dry-run
 ```
 
-`import` exits non-zero when any check fails to import, so a broken container mapping fails the build.
+`import` reports per-check failures and still exits 0, matching `checks import`. A pipeline that should fail on a broken container mapping needs to assert on the output itself, or run `plan` first and check the unresolved-container count.

--- a/docs/dbt.md
+++ b/docs/dbt.md
@@ -73,6 +73,17 @@ Every dbt test converts. Tiers grade **effort**, not feasibility.
 
 Nothing is skipped. An unrecognized generic test or a singular SQL test still produces a check, as a `satisfiesExpression` in `Draft` with the dbt source recorded in `additional_metadata`, so a reviewer adapts it rather than going back to the dbt project to find it.
 
+### Tests that become two checks
+
+A few dbt tests assert two things at once, and split:
+
+| dbt test | Becomes |
+|----------|---------|
+| `expect_column_value_lengths_to_be_between` | `minLength` + `maxLength` |
+| `expect_column_value_lengths_to_equal` | `minLength` + `maxLength` (same value) |
+
+Each half gets its own check with the UID suffixed by its rule type (`…__minlength`, `…__maxlength`), so both upsert independently. A one-sided dbt test emits only the half it specifies — `min_value` alone produces just a `minLength`. Because of this, `plan` reports check count and dbt test count separately when they differ.
+
 ## Idempotency
 
 Each check's `_qualytics_check_uid` is derived from the dbt node's `unique_id`:
@@ -123,6 +134,7 @@ Native dbt, `dbt_utils`, and `dbt_expectations` generic tests are mapped in `qua
 | `dbt_expectations.expect_column_values_to_match_regex` | `matchesPattern` | direct |
 | `dbt_expectations.expect_table_row_count_to_be_between` | `volumetric` | normalize |
 | `dbt_expectations.expect_row_values_to_have_recent_data` | `freshness` | normalize |
+| `dbt_expectations.expect_column_value_lengths_to_be_between` | `minLength` + `maxLength` | direct |
 | singular (bespoke SQL) tests | `satisfiesExpression` | manual |
 | anything unrecognized | `satisfiesExpression` | manual |
 

--- a/docs/dbt.md
+++ b/docs/dbt.md
@@ -1,0 +1,137 @@
+# dbt Migration
+
+Convert an existing dbt test suite into Qualytics quality checks. Point the CLI at a compiled `manifest.json`; conversion happens in memory and the checks upsert into a datastore.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `dbt plan` | Preview what a manifest would migrate to (offline, no auth) |
+| `dbt import` | Convert a manifest and import the checks (upsert) |
+
+## Prerequisites
+
+1. A compiled dbt manifest — `dbt compile` writes `target/manifest.json`.
+2. **The target datastore must already be catalogued.** Checks reference containers and fields by name, resolved to IDs at import. Run `qualytics operations catalog --datastore-id N` first.
+
+Only `manifest.json` is needed. It carries no database credentials (those live in `profiles.yml`, which dbt never compiles into the manifest), but it does include compiled SQL and full schema lineage — treat it like source code.
+
+## Plan
+
+```bash
+qualytics dbt plan --manifest target/manifest.json
+qualytics dbt plan --manifest target/manifest.json --show-checks
+```
+
+```
+    dbt → Qualytics coverage
+┏━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━┓
+┃ Tier      ┃ Tests ┃ Lands as ┃
+┡━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━┩
+│ direct    │    19 │ Active   │
+│ normalize │     6 │ Draft    │
+│ manual    │     3 │ Draft    │
+│ total     │    28 │          │
+└───────────┴───────┴──────────┘
+```
+
+`plan` never constructs an API client, so it works offline and in CI without credentials.
+
+## Import
+
+```bash
+# Preview
+qualytics dbt import --manifest target/manifest.json --datastore-id 42 --dry-run
+
+# Apply
+qualytics dbt import --manifest target/manifest.json --datastore-id 42
+
+# Also write the converted YAML for git / review
+qualytics dbt import --manifest target/manifest.json --datastore-id 42 \
+  --emit-yaml ./qualytics-config/checks/
+```
+
+| Option | Description |
+|--------|-------------|
+| `--datastore-id` | Target datastore (repeat for multiple) |
+| `--manifest`, `-m` | Path to `manifest.json` (default `target/manifest.json`) |
+| `--dry-run` | Preview creates/updates without writing |
+| `--container-map` | Override a container name: `model=container` (repeatable) |
+| `--container-case` | Force container name case: `upper` or `lower` |
+| `--preserve-status` | Omit `status` so re-imports keep what was set in the product |
+| `--emit-yaml` | Also write the converted checks to a directory |
+
+## Migration tiers
+
+Every dbt test converts. Tiers grade **effort**, not feasibility.
+
+| Tier | Meaning | Lands as |
+|------|---------|----------|
+| `direct` | Deterministic 1:1 mapping | `Active` |
+| `normalize` | Mapped, but a parameter needs a human eye | `Draft` |
+| `manual` | Custom SQL — the expression must be authored | `Draft` |
+
+Nothing is skipped. An unrecognized generic test or a singular SQL test still produces a check, as a `satisfiesExpression` in `Draft` with the dbt source recorded in `additional_metadata`, so a reviewer adapts it rather than going back to the dbt project to find it.
+
+## Idempotency
+
+Each check's `_qualytics_check_uid` is derived from the dbt node's `unique_id`:
+
+```yaml
+additional_metadata:
+  _qualytics_check_uid: dbt__test_jaffle_not_null_stg_orders_order_id_a1b2c3
+  dbt_unique_id: test.jaffle.not_null_stg_orders_order_id.a1b2c3
+  dbt_test: not_null
+```
+
+Re-running after the dbt suite changes updates checks in place rather than duplicating them. This deliberately does **not** use the `container__rule__fields` scheme that `checks export` uses: several dbt tests routinely share a container/rule/field triple (multiple singular tests on one model, two `expression_is_true` on one column), and the importer upserts on UID collision — so a shared UID would silently discard a test.
+
+### Status on re-import
+
+By default `import` sets `status` from the tier, which means a re-import resets a check someone activated in the product back to `Draft`. Two ways to handle it:
+
+- **Config-as-code** — treat the YAML as the source of truth. Activate by editing `status` in the emitted file, not in the UI.
+- **`--preserve-status`** — omit `status` entirely so the importer keeps whatever the check currently has.
+
+## Container name resolution
+
+Container names come from the dbt model's `alias` (falling back to `name`), because Qualytics catalogues containers from the warehouse rather than from dbt. When those differ:
+
+```bash
+# Snowflake uppercases identifiers
+qualytics dbt import -m target/manifest.json --datastore-id 42 --container-case upper
+
+# Explicit override
+qualytics dbt import -m target/manifest.json --datastore-id 42 \
+  --container-map stg_orders=ORDERS_RAW --container-map fct_sales=SALES_FACT
+```
+
+A `Container 'x' not found` error usually means the datastore has not been catalogued, or the warehouse table name differs from dbt's alias.
+
+## Supported dbt tests
+
+Native dbt, `dbt_utils`, and `dbt_expectations` generic tests are mapped in `qualytics/services/dbt.py` (`DBT_RULE_MAP`). Highlights:
+
+| dbt test | Qualytics rule | Tier |
+|----------|----------------|------|
+| `not_null` | `notNull` | direct |
+| `unique` | `unique` | direct |
+| `accepted_values` | `expectedValues` | direct |
+| `relationships` | `existsIn` | direct |
+| `dbt_utils.accepted_range` | `between` | direct |
+| `dbt_utils.expression_is_true` | `satisfiesExpression` | normalize |
+| `dbt_expectations.expect_column_values_to_match_regex` | `matchesPattern` | direct |
+| `dbt_expectations.expect_table_row_count_to_be_between` | `volumetric` | normalize |
+| `dbt_expectations.expect_row_values_to_have_recent_data` | `freshness` | normalize |
+| singular (bespoke SQL) tests | `satisfiesExpression` | manual |
+| anything unrecognized | `satisfiesExpression` | manual |
+
+## CI
+
+```yaml
+- run: dbt compile
+- run: qualytics dbt plan --manifest target/manifest.json
+- run: qualytics dbt import --manifest target/manifest.json --datastore-id ${{ vars.DS_ID }} --dry-run
+```
+
+`import` exits non-zero when any check fails to import, so a broken container mapping fails the build.

--- a/qualytics/api/compatibility.py
+++ b/qualytics/api/compatibility.py
@@ -35,6 +35,7 @@ KNOWN_API_OPERATIONS = frozenset(
         ("PUT", "/api/containers/{container_id}"),
         ("DELETE", "/api/containers/{container_id}"),
         ("GET", "/api/containers/{container_id}/field-profiles"),
+        ("GET", "/api/containers/{container_id}/fields"),
         ("GET", "/api/datastores"),
         ("POST", "/api/datastores"),
         ("POST", "/api/datastores/connection"),

--- a/qualytics/api/fields.py
+++ b/qualytics/api/fields.py
@@ -1,0 +1,20 @@
+"""Field API endpoints."""
+
+from .client import QualyticsClient
+
+
+def list_container_fields(client: QualyticsClient, container_id: int) -> list[dict]:
+    """Retrieve the fields catalogued for a container.
+
+    Returns active and missing fields by default, matching the endpoint's
+    behaviour when no status filter is supplied.
+    """
+    response = client.get(f"containers/{container_id}/fields")
+    return response.json()
+
+
+def container_field_names(client: QualyticsClient, container_id: int) -> list[str]:
+    """Just the field names for a container, in catalogue casing."""
+    return [
+        f["name"] for f in list_container_fields(client, container_id) if f.get("name")
+    ]

--- a/qualytics/cli/dbt.py
+++ b/qualytics/cli/dbt.py
@@ -89,7 +89,7 @@ def _print_summary(converted) -> dict:
 
     table = Table(title="dbt → Qualytics coverage")
     table.add_column("Tier", style="bold")
-    table.add_column("Tests", justify="right")
+    table.add_column("Checks", justify="right")
     table.add_column("Lands as")
     table.add_row("direct", str(stats["direct"]), "[green]Active[/green]")
     table.add_row("normalize", str(stats["normalize"]), "[cyan]Draft[/cyan]")
@@ -97,8 +97,16 @@ def _print_summary(converted) -> dict:
     table.add_row("[bold]total[/bold]", f"[bold]{stats['total']}[/bold]", "")
     console.print(table)
 
+    # A few dbt tests assert two things (a length range) and become two checks,
+    # so check count can exceed test count. Say so rather than conflating them.
+    split_note = (
+        f" ([bold]{stats['dbt_tests']}[/bold] dbt tests — some assert two things "
+        "and become two checks)"
+        if stats["total"] != stats["dbt_tests"]
+        else ""
+    )
     print(
-        f"\nAll [bold]{stats['total']}[/bold] dbt tests convert. "
+        f"\nAll dbt tests convert into [bold]{stats['total']}[/bold] checks{split_note}. "
         f"[bold]{stats['automatic']}[/bold] ({stats['automatic_pct']}%) map to a rule "
         f"automatically; [bold]{stats['manual']}[/bold] need an expression authored by hand."
     )

--- a/qualytics/cli/dbt.py
+++ b/qualytics/cli/dbt.py
@@ -69,12 +69,32 @@ def _parse_container_map(pairs: list[str]) -> dict[str, str]:
     return mapping
 
 
-def _convert(manifest, container_map, container_case, preserve_status):
+_VALID_STATUS = ("Active", "Draft")
+
+
+def _resolve_status(status: str | None, preserve_status: bool) -> str | None:
+    """Validate --status and reject the combination that contradicts itself."""
+    if status is None:
+        return None
+    if preserve_status:
+        print("[red]--status and --preserve-status are mutually exclusive.[/red]")
+        raise typer.Exit(code=1)
+    match = next((s for s in _VALID_STATUS if s.lower() == status.lower()), None)
+    if match is None:
+        print(f"[red]--status must be Active or Draft, got: {status}[/red]")
+        raise typer.Exit(code=1)
+    return match
+
+
+def _convert(
+    manifest, container_map, container_case, preserve_status, status_override=None
+):
     converted = convert_manifest(
         manifest,
         container_map=_parse_container_map(container_map),
         container_case=container_case,
         include_status=not preserve_status,
+        status_override=status_override,
     )
     if not converted:
         print(
@@ -84,16 +104,22 @@ def _convert(manifest, container_map, container_case, preserve_status):
     return converted
 
 
-def _print_summary(converted) -> dict:
+def _print_summary(converted, status_override: str | None = None) -> dict:
     stats = summarize(converted)
+
+    # The "Lands as" column must reflect what will actually happen, so an
+    # override replaces the tier-derived values rather than sitting beside them.
+    def _lands(default: str, color: str) -> str:
+        shown = status_override or default
+        return f"[{color}]{shown}[/{color}]"
 
     table = Table(title="dbt → Qualytics coverage")
     table.add_column("Tier", style="bold")
     table.add_column("Checks", justify="right")
     table.add_column("Lands as")
-    table.add_row("direct", str(stats["direct"]), "[green]Active[/green]")
-    table.add_row("normalize", str(stats["normalize"]), "[cyan]Draft[/cyan]")
-    table.add_row("manual", str(stats["manual"]), "[yellow]Draft[/yellow]")
+    table.add_row("direct", str(stats["direct"]), _lands("Active", "green"))
+    table.add_row("normalize", str(stats["normalize"]), _lands("Draft", "cyan"))
+    table.add_row("manual", str(stats["manual"]), _lands("Draft", "yellow"))
     table.add_row("[bold]total[/bold]", f"[bold]{stats['total']}[/bold]", "")
     console.print(table)
 
@@ -110,10 +136,14 @@ def _print_summary(converted) -> dict:
         f"[bold]{stats['automatic']}[/bold] ({stats['automatic_pct']}%) map to a rule "
         f"automatically; [bold]{stats['manual']}[/bold] need an expression authored by hand."
     )
-    print(
-        f"[dim]Tiers grade effort, not feasibility. "
-        f"{stats['normalize'] + stats['manual']} land as Draft for review before they fire.[/dim]"
-    )
+    if status_override:
+        print(f"[dim]Tiers grade effort, not feasibility.[/dim]")
+    else:
+        print(
+            f"[dim]Tiers grade effort, not feasibility. "
+            f"{stats['normalize'] + stats['manual']} land as Draft for review "
+            "before they fire.[/dim]"
+        )
 
     if stats["unresolved_containers"]:
         print(
@@ -206,6 +236,11 @@ def dbt_import(
         "--preserve-status",
         help="Omit status so re-imports keep what was set in the product",
     ),
+    status: str = typer.Option(
+        None,
+        "--status",
+        help="Force every check to Active or Draft, overriding the tier default",
+    ),
     emit_yaml: str = typer.Option(
         None, "--emit-yaml", help="Also write the converted checks to this directory"
     ),
@@ -218,11 +253,30 @@ def dbt_import(
 
     The datastore must be catalogued first — checks reference containers and
     fields by name.
+
+    By default direct-tier checks land Active and the rest land Draft. That is a
+    recommendation, not a policy: --status overrides it in either direction.
     """
     manifest = _load_manifest(manifest_path)
-    converted = _convert(manifest, container_map, container_case, preserve_status)
+    status_override = _resolve_status(status, preserve_status)
+    converted = _convert(
+        manifest, container_map, container_case, preserve_status, status_override
+    )
 
-    stats = _print_summary(converted)
+    stats = _print_summary(converted, status_override)
+
+    if status_override:
+        print(
+            f"\n[cyan]--status {status_override}: forcing all {stats['total']} "
+            "checks, overriding the tier default.[/cyan]"
+        )
+        incomplete = stats["normalize"] + stats["manual"]
+        if status_override == "Active" and incomplete:
+            print(
+                f"[yellow]{incomplete} of them were tiered normalize/manual — those "
+                "carry incomplete properties (empty expressions, unset windows and "
+                "intervals) and may not evaluate meaningfully until edited.[/yellow]"
+            )
 
     if emit_yaml:
         _write_yaml(converted, emit_yaml)

--- a/qualytics/cli/dbt.py
+++ b/qualytics/cli/dbt.py
@@ -183,14 +183,34 @@ def _field_catalogue(
     return catalogue
 
 
+def _safe_dir_name(name: str) -> str:
+    """Reduce a manifest-derived container name to a single path segment.
+
+    A container name comes from a dbt alias, which is attacker-controlled when
+    the manifest is someone else's — an alias of `../..` or an absolute path
+    would otherwise be joined straight onto the output directory and used to
+    create or truncate files outside it.
+    """
+    candidate = os.path.basename(str(name).replace("\\", "/").strip().rstrip("/"))
+    if candidate in ("", ".", "..") or os.path.isabs(candidate):
+        return "_unresolved"
+    return candidate
+
+
 def _write_yaml(converted, out_dir: str) -> None:
     """Write one YAML file per check, grouped by container.
 
     Filenames use the dbt-derived UID rather than rule+fields, for the same reason
     the UID itself does: several dbt tests can share a container/rule/field triple.
+    The UID is slugified, so only the directory segment needs sanitizing.
     """
+    root = os.path.realpath(out_dir)
     for c in converted:
-        container_dir = os.path.join(out_dir, c.container or "_unresolved")
+        container_dir = os.path.join(root, _safe_dir_name(c.container or ""))
+        # Belt and braces: never write outside the directory the caller chose.
+        if os.path.commonpath([root, os.path.realpath(container_dir)]) != root:
+            print(f"[red]Refusing to write outside {out_dir}: {c.container}[/red]")
+            continue
         os.makedirs(container_dir, exist_ok=True)
         uid = c.check["additional_metadata"]["_qualytics_check_uid"]
         path = os.path.join(container_dir, f"{uid}.yaml")

--- a/qualytics/cli/dbt.py
+++ b/qualytics/cli/dbt.py
@@ -10,11 +10,14 @@ from rich.console import Console
 from rich.table import Table
 
 from ..api.client import get_client
+from ..api.fields import container_field_names
+from ..services.containers import get_table_ids
 from ..services.dbt import (
     TIER_DIRECT,
     TIER_MANUAL,
     TIER_NORMALIZE,
     convert_manifest,
+    resolve_check_fields,
     summarize,
     to_checks,
 )
@@ -154,6 +157,32 @@ def _print_summary(converted, status_override: str | None = None) -> dict:
     return stats
 
 
+def _field_catalogue(
+    client, datastore_id: int, containers: set[str]
+) -> dict[str, list[str]]:
+    """Catalogued field names for the containers these checks target.
+
+    Only the containers actually referenced are fetched. A container the
+    importer will reject anyway, or one whose fields cannot be read, is simply
+    left out — validation then passes those checks through rather than blocking
+    the import on a lookup problem.
+    """
+    table_ids = get_table_ids(client=client, datastore_id=datastore_id)
+    if not table_ids:
+        return {}
+
+    catalogue: dict[str, list[str]] = {}
+    for name in sorted(containers):
+        container_id = table_ids.get(name)
+        if container_id is None:
+            continue
+        try:
+            catalogue[name] = container_field_names(client, container_id)
+        except Exception as e:  # noqa: BLE001 - lookup failure must not block import
+            print(f"[dim]Could not read fields for '{name}': {e}[/dim]")
+    return catalogue
+
+
 def _write_yaml(converted, out_dir: str) -> None:
     """Write one YAML file per check, grouped by container.
 
@@ -241,6 +270,11 @@ def dbt_import(
         "--status",
         help="Force every check to Active or Draft, overriding the tier default",
     ),
+    validate_fields: bool = typer.Option(
+        True,
+        "--validate-fields/--no-validate-fields",
+        help="Check field names against the catalogue and correct their casing",
+    ),
     emit_yaml: str = typer.Option(
         None, "--emit-yaml", help="Also write the converted checks to this directory"
     ),
@@ -293,22 +327,41 @@ def dbt_import(
     summary_table.add_column("Updated", style="yellow")
     summary_table.add_column("Failed", style="red")
 
+    containers = {c["container"] for c in checks if c.get("container")}
+
     total_failed = 0
     for ds_id in datastore_id:
+        # Field names are catalogued per datastore, so this resolves per target.
+        payload = checks
+        rejected: list[dict] = []
+        if validate_fields:
+            payload, rejected, corrections = resolve_check_fields(
+                checks, _field_catalogue(client, ds_id, containers)
+            )
+            if corrections:
+                print(
+                    f"[cyan]Corrected {len(corrections)} field name(s) to catalogue "
+                    f"casing: {', '.join(corrections[:5])}"
+                    f"{'…' if len(corrections) > 5 else ''}[/cyan]"
+                )
+
         print(
-            f"\n[cyan]{'[DRY RUN] ' if dry_run else ''}Importing {len(checks)} checks "
+            f"\n[cyan]{'[DRY RUN] ' if dry_run else ''}Importing {len(payload)} checks "
             f"to datastore {ds_id}...[/cyan]"
         )
-        result = import_checks_to_datastore(client, ds_id, checks, dry_run=dry_run)
+        result = import_checks_to_datastore(client, ds_id, payload, dry_run=dry_run)
 
+        failed = result["failed"] + len(rejected)
         summary_table.add_row(
             str(ds_id),
             str(result["created"]),
             str(result["updated"]),
-            str(result["failed"]),
+            str(failed),
         )
-        total_failed += result["failed"]
+        total_failed += failed
 
+        for item in rejected:
+            print(f"  [red]{item['reason']}[/red]")
         for err in result["errors"]:
             print(f"  [red]{err}[/red]")
 
@@ -319,9 +372,10 @@ def dbt_import(
     # behaviourally identical matters more than this command's CI ergonomics.
     if total_failed:
         print(
-            "[dim]Container-not-found errors usually mean the datastore has not been "
-            "catalogued, or dbt model names differ from the warehouse tables "
-            "(try --container-map or --container-case).[/dim]"
+            "[dim]Container- and field-not-found errors usually mean the datastore "
+            "has not been catalogued, or dbt names differ from the warehouse "
+            "(try --container-map or --container-case). Field casing is corrected "
+            "automatically; --no-validate-fields skips the check entirely.[/dim]"
         )
 
     if stats["manual"] and not dry_run:

--- a/qualytics/cli/dbt.py
+++ b/qualytics/cli/dbt.py
@@ -1,0 +1,267 @@
+"""CLI commands for migrating dbt tests to Qualytics."""
+
+import json
+import os
+
+import typer
+import yaml
+from rich import print
+from rich.console import Console
+from rich.table import Table
+
+from ..api.client import get_client
+from ..services.dbt import (
+    TIER_DIRECT,
+    TIER_MANUAL,
+    TIER_NORMALIZE,
+    convert_manifest,
+    summarize,
+    to_checks,
+)
+from ..services.quality_checks import import_checks_to_datastore
+from . import add_suggestion_callback
+
+dbt_app = typer.Typer(name="dbt", help="Migrate dbt tests to Qualytics quality checks")
+add_suggestion_callback(dbt_app, "dbt")
+
+console = Console()
+
+_TIER_LABEL = {
+    TIER_DIRECT: ("direct", "green"),
+    TIER_NORMALIZE: ("normalize", "cyan"),
+    TIER_MANUAL: ("manual", "yellow"),
+}
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+
+def _load_manifest(path: str) -> dict:
+    """Read and parse a dbt manifest.json, with actionable errors."""
+    if not os.path.isfile(path):
+        print(f"[red]Manifest not found: {path}[/red]")
+        print("[dim]dbt writes it to target/manifest.json after `dbt compile`.[/dim]")
+        raise typer.Exit(code=1)
+
+    try:
+        with open(path) as f:
+            manifest = json.load(f)
+    except json.JSONDecodeError as e:
+        print(f"[red]Could not parse {path} as JSON: {e}[/red]")
+        raise typer.Exit(code=1)
+
+    if not isinstance(manifest, dict) or "nodes" not in manifest:
+        print(f"[red]{path} has no 'nodes' — is this a dbt manifest.json?[/red]")
+        raise typer.Exit(code=1)
+
+    return manifest
+
+
+def _parse_container_map(pairs: list[str]) -> dict[str, str]:
+    """Parse repeated --container-map model=container into a dict."""
+    mapping = {}
+    for pair in pairs or []:
+        if "=" not in pair:
+            print(f"[red]--container-map expects model=container, got: {pair}[/red]")
+            raise typer.Exit(code=1)
+        model, container = pair.split("=", 1)
+        mapping[model.strip()] = container.strip()
+    return mapping
+
+
+def _convert(manifest, container_map, container_case, preserve_status):
+    converted = convert_manifest(
+        manifest,
+        container_map=_parse_container_map(container_map),
+        container_case=container_case,
+        include_status=not preserve_status,
+    )
+    if not converted:
+        print(
+            "[yellow]No test nodes found in the manifest — nothing to migrate.[/yellow]"
+        )
+        raise typer.Exit(code=0)
+    return converted
+
+
+def _print_summary(converted) -> dict:
+    stats = summarize(converted)
+
+    table = Table(title="dbt → Qualytics coverage")
+    table.add_column("Tier", style="bold")
+    table.add_column("Tests", justify="right")
+    table.add_column("Lands as")
+    table.add_row("direct", str(stats["direct"]), "[green]Active[/green]")
+    table.add_row("normalize", str(stats["normalize"]), "[cyan]Draft[/cyan]")
+    table.add_row("manual", str(stats["manual"]), "[yellow]Draft[/yellow]")
+    table.add_row("[bold]total[/bold]", f"[bold]{stats['total']}[/bold]", "")
+    console.print(table)
+
+    print(
+        f"\nAll [bold]{stats['total']}[/bold] dbt tests convert. "
+        f"[bold]{stats['automatic']}[/bold] ({stats['automatic_pct']}%) map to a rule "
+        f"automatically; [bold]{stats['manual']}[/bold] need an expression authored by hand."
+    )
+    print(
+        f"[dim]Tiers grade effort, not feasibility. "
+        f"{stats['normalize'] + stats['manual']} land as Draft for review before they fire.[/dim]"
+    )
+
+    if stats["unresolved_containers"]:
+        print(
+            f"\n[red]{stats['unresolved_containers']} test(s) have no resolvable container.[/red] "
+            "[dim]Use --container-map model=container.[/dim]"
+        )
+
+    return stats
+
+
+def _write_yaml(converted, out_dir: str) -> None:
+    """Write one YAML file per check, grouped by container.
+
+    Filenames use the dbt-derived UID rather than rule+fields, for the same reason
+    the UID itself does: several dbt tests can share a container/rule/field triple.
+    """
+    for c in converted:
+        container_dir = os.path.join(out_dir, c.container or "_unresolved")
+        os.makedirs(container_dir, exist_ok=True)
+        uid = c.check["additional_metadata"]["_qualytics_check_uid"]
+        path = os.path.join(container_dir, f"{uid}.yaml")
+        with open(path, "w") as f:
+            yaml.safe_dump(c.check, f, sort_keys=False, default_flow_style=False)
+    print(f"[cyan]Wrote {len(converted)} check definitions to {out_dir}/[/cyan]")
+
+
+# ── plan ──────────────────────────────────────────────────────────────────
+
+
+@dbt_app.command("plan")
+def dbt_plan(
+    manifest_path: str = typer.Option(
+        "target/manifest.json", "--manifest", "-m", help="Path to dbt manifest.json"
+    ),
+    container_map: list[str] = typer.Option(
+        None, "--container-map", help="Override a container name: model=container"
+    ),
+    container_case: str = typer.Option(
+        None, "--container-case", help="Force container name case: upper or lower"
+    ),
+    show_checks: bool = typer.Option(
+        False, "--show-checks", help="List every dbt test and the rule it maps to"
+    ),
+):
+    """Preview what a dbt manifest would migrate to. Offline — no auth required."""
+    manifest = _load_manifest(manifest_path)
+    converted = _convert(manifest, container_map, container_case, False)
+
+    _print_summary(converted)
+
+    if show_checks:
+        detail = Table(title="Crosswalk")
+        detail.add_column("Tier")
+        detail.add_column("dbt test", style="dim")
+        detail.add_column("Container")
+        detail.add_column("Qualytics rule")
+        for c in sorted(converted, key=lambda x: (x.tier, x.dbt_test)):
+            label, color = _TIER_LABEL[c.tier]
+            detail.add_row(
+                f"[{color}]{label}[/{color}]",
+                c.dbt_test,
+                c.container or "[red]unresolved[/red]",
+                c.check["rule_type"],
+            )
+        console.print(detail)
+
+
+# ── import ────────────────────────────────────────────────────────────────
+
+
+@dbt_app.command("import")
+def dbt_import(
+    datastore_id: list[int] = typer.Option(
+        ..., "--datastore-id", help="Target datastore ID (repeat for multiple)"
+    ),
+    manifest_path: str = typer.Option(
+        "target/manifest.json", "--manifest", "-m", help="Path to dbt manifest.json"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Preview what would be created/updated"
+    ),
+    container_map: list[str] = typer.Option(
+        None, "--container-map", help="Override a container name: model=container"
+    ),
+    container_case: str = typer.Option(
+        None, "--container-case", help="Force container name case: upper or lower"
+    ),
+    preserve_status: bool = typer.Option(
+        False,
+        "--preserve-status",
+        help="Omit status so re-imports keep what was set in the product",
+    ),
+    emit_yaml: str = typer.Option(
+        None, "--emit-yaml", help="Also write the converted checks to this directory"
+    ),
+):
+    """Convert a dbt manifest and import the checks (upsert) into a datastore.
+
+    Conversion happens in memory; checks upsert on a UID derived from each dbt
+    test's unique_id, so re-running after the dbt suite changes updates in place
+    rather than duplicating.
+
+    The datastore must be catalogued first — checks reference containers and
+    fields by name.
+    """
+    manifest = _load_manifest(manifest_path)
+    converted = _convert(manifest, container_map, container_case, preserve_status)
+
+    stats = _print_summary(converted)
+
+    if emit_yaml:
+        _write_yaml(converted, emit_yaml)
+
+    client = get_client()
+    checks = to_checks(converted)
+
+    if dry_run:
+        print("\n[bold yellow]DRY RUN — no changes will be made.[/bold yellow]")
+
+    summary_table = Table(title="Import Summary")
+    summary_table.add_column("Datastore ID", style="cyan")
+    summary_table.add_column("Created", style="green")
+    summary_table.add_column("Updated", style="yellow")
+    summary_table.add_column("Failed", style="red")
+
+    total_failed = 0
+    for ds_id in datastore_id:
+        print(
+            f"\n[cyan]{'[DRY RUN] ' if dry_run else ''}Importing {len(checks)} checks "
+            f"to datastore {ds_id}...[/cyan]"
+        )
+        result = import_checks_to_datastore(client, ds_id, checks, dry_run=dry_run)
+
+        summary_table.add_row(
+            str(ds_id),
+            str(result["created"]),
+            str(result["updated"]),
+            str(result["failed"]),
+        )
+        total_failed += result["failed"]
+
+        for err in result["errors"]:
+            print(f"  [red]{err}[/red]")
+
+    console.print(summary_table)
+
+    if total_failed:
+        print(
+            "[dim]Container-not-found errors usually mean the datastore has not been "
+            "catalogued, or dbt model names differ from the warehouse tables "
+            "(try --container-map or --container-case).[/dim]"
+        )
+        raise typer.Exit(code=1)
+
+    if stats["manual"] and not dry_run:
+        print(
+            f"\n[yellow]{stats['manual']} check(s) landed as Draft with an empty "
+            "expression — author those before they can fire.[/yellow]"
+        )

--- a/qualytics/cli/dbt.py
+++ b/qualytics/cli/dbt.py
@@ -314,13 +314,15 @@ def dbt_import(
 
     console.print(summary_table)
 
+    # Failures are reported, not raised — matching `checks import`, which prints
+    # per-check errors and still exits 0. Keeping the two bulk importers
+    # behaviourally identical matters more than this command's CI ergonomics.
     if total_failed:
         print(
             "[dim]Container-not-found errors usually mean the datastore has not been "
             "catalogued, or dbt model names differ from the warehouse tables "
             "(try --container-map or --container-case).[/dim]"
         )
-        raise typer.Exit(code=1)
 
     if stats["manual"] and not dry_run:
         print(

--- a/qualytics/qualytics.py
+++ b/qualytics/qualytics.py
@@ -15,6 +15,7 @@ from .cli.datastores import datastores_app
 from .cli.connections import connections_app
 from .cli.containers import containers_app
 from .cli.anomalies import anomalies_app
+from .cli.dbt import dbt_app
 from .cli.auth import auth_app
 from .cli.export_import import export_import_app
 from .cli.mcp_cmd import mcp_app
@@ -40,6 +41,7 @@ app.add_typer(datastores_app, name="datastores")
 app.add_typer(connections_app, name="connections")
 app.add_typer(containers_app, name="containers")
 app.add_typer(anomalies_app, name="anomalies")
+app.add_typer(dbt_app, name="dbt")
 app.add_typer(auth_app, name="auth")
 app.add_typer(export_import_app, name="config")
 app.add_typer(mcp_app, name="mcp")

--- a/qualytics/services/dbt.py
+++ b/qualytics/services/dbt.py
@@ -1,0 +1,580 @@
+"""dbt manifest → Qualytics quality check conversion.
+
+Pure logic: no API client, no auth, no network. Takes a parsed ``manifest.json``
+and returns portable check dicts in the same shape as ``strip_for_export``, ready
+for ``import_checks_to_datastore``.
+
+Design invariants:
+
+* **One dbt test node → exactly one check.** The UID is derived from the dbt
+  node's ``unique_id``, which dbt guarantees unique. Never use
+  ``generate_check_uid`` here: its ``container__rule__fields`` scheme collides
+  for the cases dbt produces constantly (several singular tests on one model, two
+  ``expression_is_true`` on one column), and the importer silently *updates* on a
+  UID collision rather than erroring — so a collision loses a test with no output.
+* **Nothing is dropped.** A dbt test that cannot be mapped deterministically still
+  emits a check, as ``satisfiesExpression`` in ``Draft`` with the dbt source in the
+  description. Migration tiers grade effort, not feasibility.
+"""
+
+import re
+from typing import Any, Callable
+
+# ── Tiers ─────────────────────────────────────────────────────────────────
+# 1 = direct/deterministic, 2 = needs normalization, 3 = manual authoring.
+# Tier drives `status`: tier 1 lands Active, tiers 2 and 3 land Draft so a human
+# reviews before anything fires.
+
+TIER_DIRECT = 1
+TIER_NORMALIZE = 2
+TIER_MANUAL = 3
+
+_STATUS_BY_TIER = {
+    TIER_DIRECT: "Active",
+    TIER_NORMALIZE: "Draft",
+    TIER_MANUAL: "Draft",
+}
+
+UID_PREFIX = "dbt__"
+
+
+# ── Property builders ─────────────────────────────────────────────────────
+# Property names come from controlplane `QualityCheckProperties`
+# (app/schemas/model_schemas.py). Note `between` uses min/max — NOT
+# min_value/max_value, which is what dbt calls them — and `expectedValues` uses
+# `list`. Getting these wrong produces checks the API accepts but that test
+# nothing, so they are centralized here rather than inlined per rule.
+
+
+def _p_expected_values(kw: dict) -> dict:
+    values = kw.get("values") or kw.get("value_set") or []
+    return {"list": list(values)}
+
+
+def _p_pattern(kw: dict) -> dict:
+    return {"pattern": kw.get("regex") or kw.get("pattern") or ""}
+
+
+def _p_between(kw: dict) -> dict:
+    """dbt min_value/max_value → Qualytics min/max."""
+    props: dict[str, Any] = {}
+    if kw.get("min_value") is not None:
+        props["min"] = kw["min_value"]
+    if kw.get("max_value") is not None:
+        props["max"] = kw["max_value"]
+    return props
+
+
+def _p_value_from_min(kw: dict) -> dict:
+    return {"value": kw.get("min_value"), "inclusive": True}
+
+
+def _p_value_from_max(kw: dict) -> dict:
+    return {"value": kw.get("max_value"), "inclusive": True}
+
+
+def _p_max_length(kw: dict) -> dict:
+    value = kw.get("max_value")
+    if value is None:
+        value = kw.get("value")
+    return {"value": value}
+
+
+def _p_expression(kw: dict) -> dict:
+    return {"expression": kw.get("expression") or ""}
+
+
+_DBT_TYPE_TO_FIELD_TYPE = {
+    "int": "Integral",
+    "integer": "Integral",
+    "bigint": "Integral",
+    "smallint": "Integral",
+    "float": "Fractional",
+    "double": "Fractional",
+    "decimal": "Fractional",
+    "numeric": "Fractional",
+    "number": "Fractional",
+    "bool": "Boolean",
+    "boolean": "Boolean",
+    "string": "String",
+    "varchar": "String",
+    "text": "String",
+    "char": "String",
+    "date": "Date",
+    "timestamp": "Timestamp",
+    "datetime": "Timestamp",
+    "array": "Array",
+    "struct": "Struct",
+    "map": "MapType",
+}
+
+
+def _p_is_type(kw: dict) -> dict:
+    raw = kw.get("column_type") or kw.get("type") or ""
+    key = str(raw).strip().lower()
+    # strip parameterization, e.g. varchar(64) → varchar
+    key = re.sub(r"\(.*\)$", "", key).strip()
+    return {"field_type": _DBT_TYPE_TO_FIELD_TYPE.get(key, "Unknown")}
+
+
+class Mapping:
+    """A dbt test → Qualytics rule mapping."""
+
+    __slots__ = ("rule_type", "tier", "props", "note")
+
+    def __init__(
+        self,
+        rule_type: str,
+        tier: int,
+        props: Callable[[dict], dict] | None = None,
+        note: str | None = None,
+    ):
+        self.rule_type = rule_type
+        self.tier = tier
+        self.props = props
+        self.note = note
+
+
+# ── The crosswalk ─────────────────────────────────────────────────────────
+# Keyed by "<namespace>.<name>" for packaged tests, bare name for native dbt
+# tests. Mirrors dbt-crosswalk's ruleMap.ts; rule_type values are from
+# controlplane's RuleType enum (app/types/rule_types.py).
+
+DBT_RULE_MAP: dict[str, Mapping] = {
+    # ---- native dbt ----
+    "not_null": Mapping("notNull", TIER_DIRECT),
+    "unique": Mapping("unique", TIER_DIRECT),
+    "accepted_values": Mapping("expectedValues", TIER_DIRECT, _p_expected_values),
+    "relationships": Mapping(
+        "existsIn", TIER_DIRECT, note="reference resolved from dbt ref()"
+    ),
+    # ---- dbt_utils ----
+    "dbt_utils.unique_combination_of_columns": Mapping("unique", TIER_DIRECT),
+    "dbt_utils.accepted_range": Mapping("between", TIER_DIRECT, _p_between),
+    "dbt_utils.not_null_proportion": Mapping(
+        "notNull", TIER_NORMALIZE, note="dbt threshold % — set coverage to match"
+    ),
+    "dbt_utils.expression_is_true": Mapping(
+        "satisfiesExpression",
+        TIER_NORMALIZE,
+        _p_expression,
+        note="verify expression is valid Spark SQL",
+    ),
+    "dbt_utils.not_constant": Mapping(
+        "distinctCount", TIER_NORMALIZE, note="expects distinct count > 1"
+    ),
+    "dbt_utils.cardinality_equality": Mapping("distinctCount", TIER_NORMALIZE),
+    # ---- dbt_expectations ----
+    "dbt_expectations.expect_column_values_to_not_be_null": Mapping(
+        "notNull", TIER_DIRECT
+    ),
+    "dbt_expectations.expect_column_values_to_be_unique": Mapping(
+        "unique", TIER_DIRECT
+    ),
+    "dbt_expectations.expect_column_values_to_be_in_set": Mapping(
+        "expectedValues", TIER_DIRECT, _p_expected_values
+    ),
+    "dbt_expectations.expect_column_values_to_match_regex": Mapping(
+        "matchesPattern", TIER_DIRECT, _p_pattern
+    ),
+    "dbt_expectations.expect_column_values_to_match_like_pattern": Mapping(
+        "matchesPattern",
+        TIER_NORMALIZE,
+        _p_pattern,
+        note="SQL LIKE pattern — convert to regex",
+    ),
+    "dbt_expectations.expect_column_values_to_be_between": Mapping(
+        "between", TIER_DIRECT, _p_between
+    ),
+    "dbt_expectations.expect_column_value_lengths_to_be_between": Mapping(
+        "maxLength",
+        TIER_NORMALIZE,
+        _p_max_length,
+        note="dbt checks min and max length — add a matching minLength check",
+    ),
+    "dbt_expectations.expect_column_value_lengths_to_equal": Mapping(
+        "maxLength", TIER_NORMALIZE, _p_max_length
+    ),
+    "dbt_expectations.expect_column_values_to_be_of_type": Mapping(
+        "isType", TIER_NORMALIZE, _p_is_type, note="verify the mapped field type"
+    ),
+    "dbt_expectations.expect_column_values_to_be_in_type_list": Mapping(
+        "isType", TIER_NORMALIZE, _p_is_type, note="dbt allows several types — pick one"
+    ),
+    "dbt_expectations.expect_column_max_to_be_between": Mapping(
+        "maxValue", TIER_NORMALIZE, _p_value_from_max
+    ),
+    "dbt_expectations.expect_column_min_to_be_between": Mapping(
+        "minValue", TIER_NORMALIZE, _p_value_from_min
+    ),
+    "dbt_expectations.expect_column_mean_to_be_between": Mapping(
+        "metric", TIER_NORMALIZE, note="configure the metric aggregation"
+    ),
+    "dbt_expectations.expect_column_sum_to_be_between": Mapping(
+        "sum", TIER_NORMALIZE, _p_value_from_min
+    ),
+    "dbt_expectations.expect_column_distinct_count_to_be_less_than": Mapping(
+        "distinctCount", TIER_NORMALIZE
+    ),
+    "dbt_expectations.expect_column_distinct_count_to_equal": Mapping(
+        "distinctCount", TIER_NORMALIZE
+    ),
+    "dbt_expectations.expect_table_row_count_to_be_between": Mapping(
+        "volumetric", TIER_NORMALIZE, note="set the volumetric window"
+    ),
+    "dbt_expectations.expect_row_values_to_have_recent_data": Mapping(
+        "freshness", TIER_NORMALIZE, note="set the freshness interval"
+    ),
+    "dbt_expectations.expect_table_column_count_to_equal": Mapping(
+        "fieldCount", TIER_DIRECT, lambda kw: {"value": kw.get("value")}
+    ),
+    "dbt_expectations.expect_column_to_exist": Mapping("expectedSchema", TIER_DIRECT),
+}
+
+# Rules that carry a cross-container reference. The portable YAML uses
+# ref_container_name / ref_datastore_name; the importer resolves them to IDs.
+_CROSS_REF_RULES = frozenset({"existsIn", "notExistsIn", "isReplicaOf", "dataDiff"})
+
+# Rules that operate on the container, not a field.
+_CONTAINER_LEVEL_RULES = frozenset(
+    {"volumetric", "fieldCount", "expectedSchema", "freshness"}
+)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+
+def _slugify(text: str) -> str:
+    text = str(text).lower().strip()
+    text = re.sub(r"[^a-z0-9]+", "_", text)
+    return text.strip("_")
+
+
+def dbt_check_uid(unique_id: str) -> str:
+    """Stable UID from a dbt node's unique_id.
+
+    dbt guarantees ``unique_id`` is unique per node, which is what keeps one dbt
+    test mapped to exactly one Qualytics check across re-runs.
+    """
+    return UID_PREFIX + _slugify(unique_id)
+
+
+def _ref_model_name(to_expr: str) -> str | None:
+    """Extract the model name from a dbt ``ref('x')`` / ``ref('pkg','x')``."""
+    if not to_expr:
+        return None
+    names = re.findall(r"""['"]([^'"]+)['"]""", str(to_expr))
+    return names[-1] if names else None
+
+
+def index_models(manifest: dict) -> dict[str, dict]:
+    """Map model unique_id → node, for every model-like node in the manifest."""
+    out = {}
+    for uid, node in (manifest.get("nodes") or {}).items():
+        if node.get("resource_type") in ("model", "seed", "snapshot"):
+            out[uid] = node
+    for uid, node in (manifest.get("sources") or {}).items():
+        out[uid] = node
+    return out
+
+
+def container_name_for(node: dict, *, case: str | None = None) -> str:
+    """Resolve the warehouse table name a dbt node lands in.
+
+    Prefers ``alias`` over ``name`` because dbt models can be aliased, and the
+    Qualytics container is catalogued from the warehouse — not from dbt.
+    """
+    name = node.get("alias") or node.get("identifier") or node.get("name") or ""
+    if case == "upper":
+        return name.upper()
+    if case == "lower":
+        return name.lower()
+    return name
+
+
+def _attached_model(test_node: dict, models: dict[str, dict]) -> dict | None:
+    """Find the model a test is attached to.
+
+    A ``relationships`` test depends on two models; ``attached_node`` (dbt 1.6+)
+    disambiguates. Falls back to ``file_key_name``, then to the sole dependency.
+    """
+    attached = test_node.get("attached_node")
+    if attached and attached in models:
+        return models[attached]
+
+    deps = [
+        d for d in (test_node.get("depends_on") or {}).get("nodes") or [] if d in models
+    ]
+
+    file_key = test_node.get("file_key_name") or ""
+    if "." in file_key:
+        wanted = file_key.split(".")[-1]
+        for dep in deps:
+            if models[dep].get("name") == wanted:
+                return models[dep]
+
+    return models[deps[0]] if deps else None
+
+
+def _referenced_model(
+    test_node: dict, models: dict[str, dict], kwargs: dict
+) -> dict | None:
+    """For relationships tests, the model named by the ``to`` kwarg."""
+    wanted = _ref_model_name(kwargs.get("to", ""))
+    if not wanted:
+        return None
+    for dep in (test_node.get("depends_on") or {}).get("nodes") or []:
+        node = models.get(dep)
+        if node and node.get("name") == wanted:
+            return node
+    return None
+
+
+# ── Conversion ────────────────────────────────────────────────────────────
+
+
+class ConvertedCheck:
+    """A converted check plus the provenance needed to report on it."""
+
+    __slots__ = ("check", "tier", "dbt_test", "container", "note")
+
+    def __init__(self, check: dict, tier: int, dbt_test: str, container: str, note):
+        self.check = check
+        self.tier = tier
+        self.dbt_test = dbt_test
+        self.container = container
+        self.note = note
+
+
+def _build_check(
+    *,
+    rule_type: str,
+    container: str,
+    fields: list[str],
+    description: str,
+    unique_id: str,
+    tier: int,
+    properties: dict | None = None,
+    coverage: float = 1.0,
+    tags: list[str] | None = None,
+    extra_metadata: dict | None = None,
+    include_status: bool = True,
+) -> dict:
+    check: dict[str, Any] = {
+        "rule_type": rule_type,
+        "description": description,
+        "container": container,
+        "fields": fields,
+        "coverage": coverage,
+        "properties": properties or {},
+        "tags": tags if tags is not None else ["dbt"],
+        "additional_metadata": {
+            "_qualytics_check_uid": dbt_check_uid(unique_id),
+            "dbt_unique_id": unique_id,
+            **(extra_metadata or {}),
+        },
+    }
+    # Omitting `status` on re-sync lets the importer's merge keep whatever a human
+    # set in the product; including it would reset an activated check to Draft.
+    if include_status:
+        check["status"] = _STATUS_BY_TIER[tier]
+    return check
+
+
+def convert_manifest(
+    manifest: dict,
+    *,
+    container_map: dict[str, str] | None = None,
+    container_case: str | None = None,
+    include_status: bool = True,
+    default_coverage: float = 1.0,
+    tags: list[str] | None = None,
+) -> list[ConvertedCheck]:
+    """Convert every test node in a dbt manifest into a portable check.
+
+    ``container_map`` overrides the resolved container name per dbt model name,
+    for the cases where the warehouse table does not match dbt's alias.
+    """
+    container_map = container_map or {}
+    models = index_models(manifest)
+    out: list[ConvertedCheck] = []
+
+    for unique_id, node in sorted((manifest.get("nodes") or {}).items()):
+        if node.get("resource_type") != "test":
+            continue
+
+        model = _attached_model(node, models)
+        model_name = (model or {}).get("name") or ""
+        container = container_map.get(model_name) or container_name_for(
+            model or {}, case=container_case
+        )
+
+        meta = node.get("test_metadata")
+        if meta:
+            converted = _convert_generic(
+                node,
+                unique_id,
+                meta,
+                models,
+                container,
+                default_coverage,
+                tags,
+                include_status,
+            )
+        else:
+            converted = _convert_singular(
+                node, unique_id, container, default_coverage, tags, include_status
+            )
+
+        if converted:
+            out.append(converted)
+
+    return out
+
+
+def _convert_generic(
+    node, unique_id, meta, models, container, coverage, tags, include_status
+) -> ConvertedCheck:
+    namespace = meta.get("namespace")
+    name = meta.get("name") or ""
+    key = f"{namespace}.{name}" if namespace else name
+    kwargs = meta.get("kwargs") or {}
+
+    mapping = DBT_RULE_MAP.get(key) or DBT_RULE_MAP.get(name)
+
+    column = node.get("column_name") or kwargs.get("column_name")
+    fields = [column] if column else []
+
+    if mapping is None:
+        # Unrecognized generic test — still migrates, as a Draft for a human.
+        return ConvertedCheck(
+            _build_check(
+                rule_type="satisfiesExpression",
+                container=container,
+                fields=fields,
+                description=f"[dbt] {key} — unrecognized dbt test, author the expression by hand",
+                unique_id=unique_id,
+                tier=TIER_MANUAL,
+                properties={"expression": ""},
+                coverage=coverage,
+                tags=tags,
+                extra_metadata={"dbt_test": key},
+                include_status=include_status,
+            ),
+            TIER_MANUAL,
+            key,
+            container,
+            "unrecognized dbt test",
+        )
+
+    properties = mapping.props(kwargs) if mapping.props else {}
+
+    # Composite unique: dbt passes the column set in kwargs, not column_name.
+    if key == "dbt_utils.unique_combination_of_columns":
+        combo = kwargs.get("combination_of_columns") or []
+        fields = list(combo) or fields
+
+    if mapping.rule_type in _CROSS_REF_RULES:
+        ref = _referenced_model(node, models, kwargs)
+        if ref is not None:
+            properties = dict(properties)
+            properties["ref_container_name"] = container_name_for(ref)
+
+    if mapping.rule_type in _CONTAINER_LEVEL_RULES:
+        fields = []
+
+    description = f"[dbt] {key}"
+    if mapping.note:
+        description += f" — {mapping.note}"
+
+    return ConvertedCheck(
+        _build_check(
+            rule_type=mapping.rule_type,
+            container=container,
+            fields=fields,
+            description=description,
+            unique_id=unique_id,
+            tier=mapping.tier,
+            properties=properties,
+            coverage=coverage,
+            tags=tags,
+            extra_metadata={"dbt_test": key},
+            include_status=include_status,
+        ),
+        mapping.tier,
+        key,
+        container,
+        mapping.note,
+    )
+
+
+def _convert_singular(
+    node, unique_id, container, coverage, tags, include_status
+) -> ConvertedCheck:
+    """Singular (bespoke SQL) test → satisfiesExpression in Draft.
+
+    dbt compiles these to SQL that selects failing rows, which is not a row
+    predicate. The SQL is carried across so a reviewer adapts it rather than
+    going back to the dbt project to find it.
+    """
+    name = node.get("name") or unique_id.split(".")[-1]
+    sql = node.get("compiled_code") or node.get("raw_code") or ""
+
+    description = (
+        f"[dbt] singular test '{name}' — port the SQL to a row predicate. "
+        "dbt's version selects failing rows; Qualytics expects an expression "
+        "that is true for valid rows."
+    )
+
+    return ConvertedCheck(
+        _build_check(
+            rule_type="satisfiesExpression",
+            container=container,
+            fields=[],
+            description=description,
+            unique_id=unique_id,
+            tier=TIER_MANUAL,
+            properties={"expression": ""},
+            coverage=coverage,
+            tags=tags,
+            extra_metadata={"dbt_test": name, "dbt_compiled_sql": sql}
+            if sql
+            else {"dbt_test": name},
+            include_status=include_status,
+        ),
+        TIER_MANUAL,
+        name,
+        container,
+        "singular SQL test",
+    )
+
+
+# ── Reporting ─────────────────────────────────────────────────────────────
+
+
+def summarize(converted: list[ConvertedCheck]) -> dict:
+    """Coverage breakdown for `dbt plan`."""
+    total = len(converted)
+    by_tier = {t: 0 for t in (TIER_DIRECT, TIER_NORMALIZE, TIER_MANUAL)}
+    for c in converted:
+        by_tier[c.tier] += 1
+
+    automatic = by_tier[TIER_DIRECT] + by_tier[TIER_NORMALIZE]
+    containers = sorted({c.container for c in converted if c.container})
+    missing_container = [c for c in converted if not c.container]
+
+    return {
+        "total": total,
+        "direct": by_tier[TIER_DIRECT],
+        "normalize": by_tier[TIER_NORMALIZE],
+        "manual": by_tier[TIER_MANUAL],
+        "automatic": automatic,
+        "automatic_pct": round(automatic / total * 100) if total else 0,
+        "containers": containers,
+        "unresolved_containers": len(missing_container),
+    }
+
+
+def to_checks(converted: list[ConvertedCheck]) -> list[dict]:
+    """Strip provenance wrappers, yielding dicts for import_checks_to_datastore."""
+    return [c.check for c in converted]

--- a/qualytics/services/dbt.py
+++ b/qualytics/services/dbt.py
@@ -432,6 +432,7 @@ def convert_manifest(
     container_map: dict[str, str] | None = None,
     container_case: str | None = None,
     include_status: bool = True,
+    status_override: str | None = None,
     default_coverage: float = 1.0,
     tags: list[str] | None = None,
 ) -> list[ConvertedCheck]:
@@ -439,6 +440,10 @@ def convert_manifest(
 
     ``container_map`` overrides the resolved container name per dbt model name,
     for the cases where the warehouse table does not match dbt's alias.
+
+    ``status_override`` forces every check to one status, replacing the
+    tier-derived default. The migration is the caller's to manage: the tiers are
+    a recommendation, not a policy this function enforces.
     """
     container_map = container_map or {}
     models = index_models(manifest)
@@ -472,6 +477,10 @@ def convert_manifest(
             )
 
         out.extend(converted)
+
+    if status_override:
+        for c in out:
+            c.check["status"] = status_override
 
     return out
 

--- a/qualytics/services/dbt.py
+++ b/qualytics/services/dbt.py
@@ -84,6 +84,21 @@ def _p_value_from_max(kw: dict) -> dict:
     return {"value": kw.get("max_value"), "inclusive": True}
 
 
+def _p_sum(kw: dict) -> dict | None:
+    """`sum` asserts equality, not a range.
+
+    dataplane evaluates it as ``hasSum(field, _ == value)``. Emitting a dbt
+    range's lower bound would assert ``sum == min`` and report valid data as
+    anomalous, so only a degenerate range (min == max) converts. Anything wider
+    returns None and falls through to manual authoring with the bounds preserved
+    in metadata.
+    """
+    low, high = kw.get("min_value"), kw.get("max_value")
+    if low is not None and low == high:
+        return {"value": low}
+    return None
+
+
 # ComparisonType, from controlplane app/types/comparison_types.py.
 _LT = "less than"
 _EQ = "equal to"
@@ -354,7 +369,7 @@ DBT_RULE_MAP: dict[str, Mapping] = {
         note="metric records the field value — confirm it aggregates as a mean",
     ),
     "dbt_expectations.expect_column_sum_to_be_between": Mapping(
-        "sum", TIER_NORMALIZE, _p_value_from_min
+        "sum", TIER_NORMALIZE, _p_sum, note="sum asserts equality, not a range"
     ),
     "dbt_expectations.expect_column_distinct_count_to_be_less_than": Mapping(
         "distinctCount", TIER_DIRECT, _p_distinct_count(_LT)
@@ -664,15 +679,24 @@ def convert_manifest(
     models = index_models(manifest)
     out: list[ConvertedCheck] = []
 
+    def resolve_container(model: dict | None) -> str:
+        """Single resolution path for every container name a check refers to.
+
+        A cross-reference target (``existsIn``) has to resolve identically to the
+        check's own container; resolving them separately let --container-map and
+        --container-case apply to one and not the other.
+        """
+        name = (model or {}).get("name") or ""
+        return container_map.get(name) or container_name_for(
+            model or {}, case=container_case
+        )
+
     for unique_id, node in sorted((manifest.get("nodes") or {}).items()):
         if node.get("resource_type") != "test":
             continue
 
         model = _attached_model(node, models)
-        model_name = (model or {}).get("name") or ""
-        container = container_map.get(model_name) or container_name_for(
-            model or {}, case=container_case
-        )
+        container = resolve_container(model)
 
         meta = node.get("test_metadata")
         if meta:
@@ -685,6 +709,7 @@ def convert_manifest(
                 default_coverage,
                 tags,
                 include_status,
+                resolve_container,
             )
         else:
             converted = _convert_singular(
@@ -701,7 +726,15 @@ def convert_manifest(
 
 
 def _convert_generic(
-    node, unique_id, meta, models, container, coverage, tags, include_status
+    node,
+    unique_id,
+    meta,
+    models,
+    container,
+    coverage,
+    tags,
+    include_status,
+    resolve_container,
 ) -> list[ConvertedCheck]:
     namespace = meta.get("namespace")
     name = meta.get("name") or ""
@@ -777,6 +810,12 @@ def _convert_generic(
 
     properties = mapping.props(kwargs) if mapping.props else {}
 
+    # A builder returns None when the rule cannot express what the dbt test
+    # asserts. Converting anyway would change the assertion's meaning, so the
+    # test degrades to manual authoring instead — with its kwargs preserved.
+    if properties is None:
+        return _unmapped(f"{mapping.rule_type} cannot express this dbt assertion")
+
     # Composite unique: dbt passes the column set in kwargs, not column_name.
     if key == "dbt_utils.unique_combination_of_columns":
         combo = kwargs.get("combination_of_columns") or []
@@ -786,7 +825,10 @@ def _convert_generic(
         ref = _referenced_model(node, models, kwargs)
         if ref is not None:
             properties = dict(properties)
-            properties["ref_container_name"] = container_name_for(ref)
+            # The referenced container must go through the same resolution as the
+            # primary one, or --container-map/--container-case would resolve the
+            # source and leave the target as a name the importer cannot find.
+            properties["ref_container_name"] = resolve_container(ref)
 
     # Container-level rules take no fields; _build_check enforces that from the
     # rule contract rather than a second list kept in sync here.

--- a/qualytics/services/dbt.py
+++ b/qualytics/services/dbt.py
@@ -390,6 +390,62 @@ class ConvertedCheck:
         self.note = note
 
 
+# kwargs already expressed elsewhere in the check, so recording them again in
+# metadata would be noise rather than information.
+_REDUNDANT_KWARGS = frozenset({"column_name"})
+
+
+def row_filter(node: dict) -> str | None:
+    """dbt's ``where`` config → Qualytics ``filter``.
+
+    Both are a SQL predicate scoping which rows the assertion applies to.
+    Dropping it would run the check against precisely the rows dbt was told to
+    exclude, so this is a correctness mapping, not an enhancement.
+    """
+    where = (node.get("config") or {}).get("where")
+    return str(where) if where else None
+
+
+def dbt_metadata(node: dict, key: str, kwargs: dict | None = None) -> dict:
+    """dbt facts with no direct Qualytics field, recorded rather than dropped.
+
+    A reviewer completing a Draft check should not have to go back to the dbt
+    project to find the threshold or interval the test was written with, so
+    everything unconsumed lands here. ``additional_metadata`` is typed
+    ``dict[str, Any]`` server-side, so structured values need no encoding.
+    """
+    meta: dict[str, Any] = {"dbt_test": key}
+
+    package = node.get("package_name")
+    if package:
+        meta["dbt_package"] = package
+
+    config = node.get("config") or {}
+
+    # Only record severity when it departs from dbt's default.
+    severity = config.get("severity")
+    if severity and str(severity).lower() != "error":
+        meta["dbt_severity"] = str(severity)
+
+    for cfg in ("limit", "store_failures", "error_if", "warn_if"):
+        if config.get(cfg) is not None:
+            meta[f"dbt_{cfg}"] = config[cfg]
+
+    tags = config.get("tags") or node.get("tags")
+    if tags:
+        meta["dbt_tags"] = (
+            list(tags) if isinstance(tags, (list, tuple)) else [str(tags)]
+        )
+
+    # Every kwarg the mapping did not turn into a property or field. Keeps the
+    # thresholds of a partially-mapped rule visible on the check itself.
+    leftover = {k: v for k, v in (kwargs or {}).items() if k not in _REDUNDANT_KWARGS}
+    if leftover:
+        meta["dbt_kwargs"] = leftover
+
+    return meta
+
+
 def _build_check(
     *,
     rule_type: str,
@@ -404,6 +460,7 @@ def _build_check(
     extra_metadata: dict | None = None,
     include_status: bool = True,
     uid_suffix: str | None = None,
+    check_filter: str | None = None,
 ) -> dict:
     check: dict[str, Any] = {
         "rule_type": rule_type,
@@ -411,6 +468,7 @@ def _build_check(
         "container": container,
         "fields": fields,
         "coverage": coverage,
+        "filter": check_filter,
         "properties": properties or {},
         "tags": tags if tags is not None else ["dbt"],
         "additional_metadata": {
@@ -512,8 +570,9 @@ def _convert_generic(
                     properties={"expression": ""},
                     coverage=coverage,
                     tags=tags,
-                    extra_metadata={"dbt_test": key},
+                    extra_metadata=dbt_metadata(node, key, kwargs),
                     include_status=include_status,
+                    check_filter=row_filter(node),
                 ),
                 TIER_MANUAL,
                 key,
@@ -546,9 +605,10 @@ def _convert_generic(
                         properties=props,
                         coverage=coverage,
                         tags=tags,
-                        extra_metadata={"dbt_test": key},
+                        extra_metadata=dbt_metadata(node, key, kwargs),
                         include_status=include_status,
                         uid_suffix=split.rule_type,
+                        check_filter=row_filter(node),
                     ),
                     mapping.tier,
                     key,
@@ -590,8 +650,9 @@ def _convert_generic(
                 properties=properties,
                 coverage=coverage,
                 tags=tags,
-                extra_metadata={"dbt_test": key},
+                extra_metadata=dbt_metadata(node, key, kwargs),
                 include_status=include_status,
+                check_filter=row_filter(node),
             ),
             mapping.tier,
             key,
@@ -619,6 +680,10 @@ def _convert_singular(
         "that is true for valid rows."
     )
 
+    metadata = dbt_metadata(node, name)
+    if sql:
+        metadata["dbt_compiled_sql"] = sql
+
     return [
         ConvertedCheck(
             _build_check(
@@ -631,10 +696,9 @@ def _convert_singular(
                 properties={"expression": ""},
                 coverage=coverage,
                 tags=tags,
-                extra_metadata={"dbt_test": name, "dbt_compiled_sql": sql}
-                if sql
-                else {"dbt_test": name},
+                extra_metadata=metadata,
                 include_status=include_status,
+                check_filter=row_filter(node),
             ),
             TIER_MANUAL,
             name,

--- a/qualytics/services/dbt.py
+++ b/qualytics/services/dbt.py
@@ -20,7 +20,8 @@ Design invariants:
 """
 
 import re
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 # ── Tiers ─────────────────────────────────────────────────────────────────
 # 1 = direct/deterministic, 2 = needs normalization, 3 = manual authoring.

--- a/qualytics/services/dbt.py
+++ b/qualytics/services/dbt.py
@@ -744,3 +744,69 @@ def summarize(converted: list[ConvertedCheck]) -> dict:
 def to_checks(converted: list[ConvertedCheck]) -> list[dict]:
     """Strip provenance wrappers, yielding dicts for import_checks_to_datastore."""
     return [c.check for c in converted]
+
+
+# ── Field validation ──────────────────────────────────────────────────────
+
+
+def resolve_check_fields(
+    checks: list[dict], fields_by_container: dict[str, list[str]]
+) -> tuple[list[dict], list[dict], list[str]]:
+    """Match each check's fields against the catalogued field names.
+
+    ``import_checks_to_datastore`` resolves container names to IDs and errors on
+    a miss, but passes ``fields`` through untouched — so a field name that does
+    not exist in the warehouse creates a check that never evaluates, with no
+    error anywhere. Checking against the catalogue closes that gap.
+
+    Because the catalogue is ground truth, this also fixes casing rather than
+    guessing at it: dbt writes ``order_id``, Snowflake catalogues ``ORDER_ID``,
+    and the right answer is knowable instead of a flag the user has to set.
+
+    A container absent from ``fields_by_container`` passes through untouched —
+    the importer reports unknown containers itself, and this must not
+    second-guess it.
+
+    Returns ``(importable, rejected, corrections)``.
+    """
+    importable: list[dict] = []
+    rejected: list[dict] = []
+    corrections: list[str] = []
+
+    for check in checks:
+        container = check.get("container") or ""
+        known = fields_by_container.get(container)
+        if known is None:
+            importable.append(check)
+            continue
+
+        exact = set(known)
+        by_lower = {name.lower(): name for name in known}
+
+        resolved: list[str] = []
+        missing: list[str] = []
+        for field in check.get("fields") or []:
+            if field in exact:
+                resolved.append(field)
+            elif field.lower() in by_lower:
+                actual = by_lower[field.lower()]
+                resolved.append(actual)
+                corrections.append(f"{container}.{field} → {actual}")
+            else:
+                missing.append(field)
+
+        if missing:
+            rejected.append(
+                {
+                    "check": check,
+                    "reason": (
+                        f"Field(s) not found in container '{container}': "
+                        f"{', '.join(missing)}"
+                    ),
+                }
+            )
+            continue
+
+        importable.append({**check, "fields": resolved})
+
+    return importable, rejected, corrections

--- a/qualytics/services/dbt.py
+++ b/qualytics/services/dbt.py
@@ -58,12 +58,20 @@ def _p_pattern(kw: dict) -> dict:
 
 
 def _p_between(kw: dict) -> dict:
-    """dbt min_value/max_value → Qualytics min/max."""
+    """dbt min_value/max_value → Qualytics min/max.
+
+    `between` wants min/inclusive_min/max/inclusive_max, so each bound's
+    inclusivity is stated rather than left to a server default — dbt ranges are
+    inclusive. A one-sided dbt range yields a one-sided check rather than a
+    fabricated opposite bound.
+    """
     props: dict[str, Any] = {}
     if kw.get("min_value") is not None:
         props["min"] = kw["min_value"]
+        props["inclusive_min"] = True
     if kw.get("max_value") is not None:
         props["max"] = kw["max_value"]
+        props["inclusive_max"] = True
     return props
 
 
@@ -73,6 +81,95 @@ def _p_value_from_min(kw: dict) -> dict:
 
 def _p_value_from_max(kw: dict) -> dict:
     return {"value": kw.get("max_value"), "inclusive": True}
+
+
+# ComparisonType, from controlplane app/types/comparison_types.py.
+_LT = "less than"
+_EQ = "equal to"
+_GT = "greater than"
+
+# Metric/Volumetric comparison, from their respective enums.
+_ABSOLUTE_VALUE = "Absolute Value"
+
+
+def _p_distinct_count(comparison: str):
+    """distinctCount requires both `comparison` and `value`."""
+
+    def build(kw: dict) -> dict:
+        value = kw.get("value")
+        if value is None:
+            value = kw.get("max_value")
+        return {"comparison": comparison, "value": value}
+
+    return build
+
+
+def _p_not_constant(kw: dict) -> dict:
+    """`not_constant` asserts more than one distinct value."""
+    return {"comparison": _GT, "value": 1}
+
+
+def _p_exists_in(kw: dict) -> dict:
+    """existsIn needs the referenced field; the container is resolved later."""
+    field = kw.get("field")
+    return {"field_name": field} if field else {}
+
+
+def _p_expected_schema(kw: dict) -> dict:
+    """`expect_column_to_exist` asserts one column is present, others allowed."""
+    column = kw.get("column_name")
+    return {
+        "list": [column] if column else [],
+        "allow_other_fields": True,
+    }
+
+
+# dbt datepart → milliseconds, for freshness. controlplane documents freshness
+# `value` as the maximum allowed age in MILLISECONDS.
+_DATEPART_MS = {
+    "second": 1_000,
+    "minute": 60_000,
+    "hour": 3_600_000,
+    "day": 86_400_000,
+    "week": 604_800_000,
+    "month": 2_592_000_000,  # 30 days
+    "year": 31_536_000_000,  # 365 days
+}
+
+
+def _p_freshness(kw: dict) -> dict:
+    """dbt datepart+interval → freshness max age in milliseconds."""
+    datepart = str(kw.get("datepart") or "day").strip().lower().rstrip("s")
+    interval = kw.get("interval")
+    unit = _DATEPART_MS.get(datepart)
+    if unit is None or interval is None:
+        return {}
+    return {"value": int(interval) * unit}
+
+
+def _p_volumetric(kw: dict) -> dict:
+    """dbt's absolute row-count range → volumetric with an absolute comparison.
+
+    volumetric is drift-oriented and requires a `window_size` for its moving
+    average; dbt has no equivalent concept, so an absolute-value comparison over
+    a single-day window is the closest faithful reading. It stays Draft so the
+    window is confirmed rather than assumed.
+    """
+    return {
+        "comparison": _ABSOLUTE_VALUE,
+        "window_size": 1,
+        "min": kw.get("min_value"),
+        "max": kw.get("max_value"),
+    }
+
+
+def _p_metric(kw: dict) -> dict:
+    """metric requires `comparison`; dbt supplies the absolute bounds."""
+    return {
+        "comparison": _ABSOLUTE_VALUE,
+        "min": kw.get("min_value"),
+        "max": kw.get("max_value"),
+    }
 
 
 # Length builders return None when their bound is absent, so a one-sided dbt
@@ -182,7 +279,7 @@ DBT_RULE_MAP: dict[str, Mapping] = {
     "unique": Mapping("unique", TIER_DIRECT),
     "accepted_values": Mapping("expectedValues", TIER_DIRECT, _p_expected_values),
     "relationships": Mapping(
-        "existsIn", TIER_DIRECT, note="reference resolved from dbt ref()"
+        "existsIn", TIER_DIRECT, _p_exists_in, note="reference resolved from dbt ref()"
     ),
     # ---- dbt_utils ----
     "dbt_utils.unique_combination_of_columns": Mapping("unique", TIER_DIRECT),
@@ -196,10 +293,12 @@ DBT_RULE_MAP: dict[str, Mapping] = {
         _p_expression,
         note="verify expression is valid Spark SQL",
     ),
-    "dbt_utils.not_constant": Mapping(
-        "distinctCount", TIER_NORMALIZE, note="expects distinct count > 1"
+    "dbt_utils.not_constant": Mapping("distinctCount", TIER_DIRECT, _p_not_constant),
+    "dbt_utils.cardinality_equality": Mapping(
+        "distinctCount",
+        TIER_NORMALIZE,
+        note="dbt compares two columns' cardinality — set the expected count",
     ),
-    "dbt_utils.cardinality_equality": Mapping("distinctCount", TIER_NORMALIZE),
     # ---- dbt_expectations ----
     "dbt_expectations.expect_column_values_to_not_be_null": Mapping(
         "notNull", TIER_DIRECT
@@ -248,37 +347,88 @@ DBT_RULE_MAP: dict[str, Mapping] = {
         "minValue", TIER_NORMALIZE, _p_value_from_min
     ),
     "dbt_expectations.expect_column_mean_to_be_between": Mapping(
-        "metric", TIER_NORMALIZE, note="configure the metric aggregation"
+        "metric",
+        TIER_NORMALIZE,
+        _p_metric,
+        note="metric records the field value — confirm it aggregates as a mean",
     ),
     "dbt_expectations.expect_column_sum_to_be_between": Mapping(
         "sum", TIER_NORMALIZE, _p_value_from_min
     ),
     "dbt_expectations.expect_column_distinct_count_to_be_less_than": Mapping(
-        "distinctCount", TIER_NORMALIZE
+        "distinctCount", TIER_DIRECT, _p_distinct_count(_LT)
     ),
     "dbt_expectations.expect_column_distinct_count_to_equal": Mapping(
-        "distinctCount", TIER_NORMALIZE
+        "distinctCount", TIER_DIRECT, _p_distinct_count(_EQ)
     ),
     "dbt_expectations.expect_table_row_count_to_be_between": Mapping(
-        "volumetric", TIER_NORMALIZE, note="set the volumetric window"
+        "volumetric",
+        TIER_NORMALIZE,
+        _p_volumetric,
+        note="confirm the moving-average window; dbt has no equivalent",
     ),
     "dbt_expectations.expect_row_values_to_have_recent_data": Mapping(
-        "freshness", TIER_NORMALIZE, note="set the freshness interval"
+        "freshness", TIER_DIRECT, _p_freshness
     ),
     "dbt_expectations.expect_table_column_count_to_equal": Mapping(
         "fieldCount", TIER_DIRECT, lambda kw: {"value": kw.get("value")}
     ),
-    "dbt_expectations.expect_column_to_exist": Mapping("expectedSchema", TIER_DIRECT),
+    "dbt_expectations.expect_column_to_exist": Mapping(
+        "expectedSchema", TIER_DIRECT, _p_expected_schema
+    ),
 }
 
 # Rules that carry a cross-container reference. The portable YAML uses
 # ref_container_name / ref_datastore_name; the importer resolves them to IDs.
 _CROSS_REF_RULES = frozenset({"existsIn", "notExistsIn", "isReplicaOf", "dataDiff"})
 
-# Rules that operate on the container, not a field.
-_CONTAINER_LEVEL_RULES = frozenset(
-    {"volumetric", "fieldCount", "expectedSchema", "freshness"}
-)
+
+class Contract:
+    """Per-rule capabilities, from controlplane's quality_check_specs().
+
+    Not every rule accepts every top-level field: `volumetric` and `freshness`
+    are container-level and reject a filter, and several rules do not support
+    coverage. Emitting those anyway produces a payload the API has no meaning
+    for, so the contract is encoded rather than assumed uniform.
+    """
+
+    __slots__ = ("fields", "filterable", "coverage")
+
+    def __init__(self, fields: str, filterable: bool, coverage: bool):
+        self.fields = fields  # multi | single | calculated | none
+        self.filterable = filterable
+        self.coverage = coverage
+
+
+RULE_CONTRACT: dict[str, Contract] = {
+    "notNull": Contract("multi", True, True),
+    "unique": Contract("multi", True, True),
+    "expectedValues": Contract("single", True, True),
+    "existsIn": Contract("single", True, True),
+    "between": Contract("single", True, True),
+    "greaterThan": Contract("single", True, True),
+    "lessThan": Contract("single", True, True),
+    "satisfiesExpression": Contract("calculated", True, True),
+    "distinctCount": Contract("single", True, False),
+    "matchesPattern": Contract("single", True, True),
+    "maxLength": Contract("single", True, True),
+    "minLength": Contract("single", True, True),
+    "isType": Contract("single", True, True),
+    "maxValue": Contract("single", True, True),
+    "minValue": Contract("single", True, True),
+    "metric": Contract("single", True, False),
+    "sum": Contract("single", True, True),
+    "volumetric": Contract("none", False, False),
+    "freshness": Contract("none", False, False),
+    "fieldCount": Contract("none", False, False),
+    "expectedSchema": Contract("none", False, False),
+}
+
+_DEFAULT_CONTRACT = Contract("single", True, True)
+
+
+def contract_for(rule_type: str) -> Contract:
+    return RULE_CONTRACT.get(rule_type, _DEFAULT_CONTRACT)
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────
@@ -462,13 +612,19 @@ def _build_check(
     uid_suffix: str | None = None,
     check_filter: str | None = None,
 ) -> dict:
+    # The rule's contract decides which top-level fields are meaningful. A
+    # container-level rule takes no fields and rejects a filter; several rules
+    # do not support coverage. Emitting them regardless would be noise the API
+    # has to ignore, or reject.
+    contract = contract_for(rule_type)
+
     check: dict[str, Any] = {
         "rule_type": rule_type,
         "description": description,
         "container": container,
-        "fields": fields,
-        "coverage": coverage,
-        "filter": check_filter,
+        "fields": [] if contract.fields == "none" else fields,
+        "coverage": coverage if contract.coverage else None,
+        "filter": check_filter if contract.filterable else None,
         "properties": properties or {},
         "tags": tags if tags is not None else ["dbt"],
         "additional_metadata": {
@@ -631,8 +787,8 @@ def _convert_generic(
             properties = dict(properties)
             properties["ref_container_name"] = container_name_for(ref)
 
-    if mapping.rule_type in _CONTAINER_LEVEL_RULES:
-        fields = []
+    # Container-level rules take no fields; _build_check enforces that from the
+    # rule contract rather than a second list kept in sync here.
 
     description = f"[dbt] {key}"
     if mapping.note:

--- a/qualytics/services/dbt.py
+++ b/qualytics/services/dbt.py
@@ -6,12 +6,14 @@ for ``import_checks_to_datastore``.
 
 Design invariants:
 
-* **One dbt test node → exactly one check.** The UID is derived from the dbt
-  node's ``unique_id``, which dbt guarantees unique. Never use
-  ``generate_check_uid`` here: its ``container__rule__fields`` scheme collides
-  for the cases dbt produces constantly (several singular tests on one model, two
-  ``expression_is_true`` on one column), and the importer silently *updates* on a
-  UID collision rather than erroring — so a collision loses a test with no output.
+* **Every UID is distinct.** The UID is derived from the dbt node's
+  ``unique_id``, which dbt guarantees unique, plus a rule-type suffix for the few
+  tests that split into two checks (a length range is a minLength *and* a
+  maxLength). Never use ``generate_check_uid`` here: its
+  ``container__rule__fields`` scheme collides for the cases dbt produces
+  constantly (several singular tests on one model, two ``expression_is_true`` on
+  one column), and the importer silently *updates* on a UID collision rather than
+  erroring — so a collision loses a check with no output.
 * **Nothing is dropped.** A dbt test that cannot be mapped deterministically still
   emits a check, as ``satisfiesExpression`` in ``Draft`` with the dbt source in the
   description. Migration tiers grade effort, not feasibility.
@@ -73,11 +75,24 @@ def _p_value_from_max(kw: dict) -> dict:
     return {"value": kw.get("max_value"), "inclusive": True}
 
 
-def _p_max_length(kw: dict) -> dict:
+# Length builders return None when their bound is absent, so a one-sided dbt
+# test emits only the half it actually specifies.
+
+
+def _p_min_length(kw: dict) -> dict | None:
+    value = kw.get("min_value")
+    return {"value": value} if value is not None else None
+
+
+def _p_max_length(kw: dict) -> dict | None:
     value = kw.get("max_value")
-    if value is None:
-        value = kw.get("value")
-    return {"value": value}
+    return {"value": value} if value is not None else None
+
+
+def _p_exact_length(kw: dict) -> dict | None:
+    """`lengths_to_equal` pins both ends to the same value."""
+    value = kw.get("value")
+    return {"value": value} if value is not None else None
 
 
 def _p_expression(kw: dict) -> dict:
@@ -117,10 +132,29 @@ def _p_is_type(kw: dict) -> dict:
     return {"field_type": _DBT_TYPE_TO_FIELD_TYPE.get(key, "Unknown")}
 
 
-class Mapping:
-    """A dbt test → Qualytics rule mapping."""
+class Split:
+    """One of several checks produced from a single dbt test.
 
-    __slots__ = ("rule_type", "tier", "props", "note")
+    ``props`` returns None when this half of the test is not specified, so the
+    split is skipped rather than emitting a check with a null bound.
+    """
+
+    __slots__ = ("rule_type", "props")
+
+    def __init__(self, rule_type: str, props: Callable[[dict], dict | None]):
+        self.rule_type = rule_type
+        self.props = props
+
+
+class Mapping:
+    """A dbt test → Qualytics rule mapping.
+
+    ``splits`` covers dbt tests that assert two things at once (a length range is
+    a minLength *and* a maxLength). Each split becomes its own check with a
+    UID suffixed by its rule type, keeping every UID distinct.
+    """
+
+    __slots__ = ("rule_type", "tier", "props", "note", "splits")
 
     def __init__(
         self,
@@ -128,11 +162,13 @@ class Mapping:
         tier: int,
         props: Callable[[dict], dict] | None = None,
         note: str | None = None,
+        splits: list[Split] | None = None,
     ):
         self.rule_type = rule_type
         self.tier = tier
         self.props = props
         self.note = note
+        self.splits = splits
 
 
 # ── The crosswalk ─────────────────────────────────────────────────────────
@@ -187,13 +223,17 @@ DBT_RULE_MAP: dict[str, Mapping] = {
         "between", TIER_DIRECT, _p_between
     ),
     "dbt_expectations.expect_column_value_lengths_to_be_between": Mapping(
-        "maxLength",
-        TIER_NORMALIZE,
-        _p_max_length,
-        note="dbt checks min and max length — add a matching minLength check",
+        "minLength",
+        TIER_DIRECT,
+        splits=[Split("minLength", _p_min_length), Split("maxLength", _p_max_length)],
     ),
     "dbt_expectations.expect_column_value_lengths_to_equal": Mapping(
-        "maxLength", TIER_NORMALIZE, _p_max_length
+        "minLength",
+        TIER_DIRECT,
+        splits=[
+            Split("minLength", _p_exact_length),
+            Split("maxLength", _p_exact_length),
+        ],
     ),
     "dbt_expectations.expect_column_values_to_be_of_type": Mapping(
         "isType", TIER_NORMALIZE, _p_is_type, note="verify the mapped field type"
@@ -250,13 +290,17 @@ def _slugify(text: str) -> str:
     return text.strip("_")
 
 
-def dbt_check_uid(unique_id: str) -> str:
+def dbt_check_uid(unique_id: str, suffix: str | None = None) -> str:
     """Stable UID from a dbt node's unique_id.
 
-    dbt guarantees ``unique_id`` is unique per node, which is what keeps one dbt
-    test mapped to exactly one Qualytics check across re-runs.
+    dbt guarantees ``unique_id`` is unique per node. ``suffix`` distinguishes the
+    checks of a split mapping (one dbt test asserting two things), keeping every
+    emitted UID distinct.
     """
-    return UID_PREFIX + _slugify(unique_id)
+    uid = UID_PREFIX + _slugify(unique_id)
+    if suffix:
+        uid += "__" + _slugify(suffix)
+    return uid
 
 
 def _ref_model_name(to_expr: str) -> str | None:
@@ -359,6 +403,7 @@ def _build_check(
     tags: list[str] | None = None,
     extra_metadata: dict | None = None,
     include_status: bool = True,
+    uid_suffix: str | None = None,
 ) -> dict:
     check: dict[str, Any] = {
         "rule_type": rule_type,
@@ -369,7 +414,7 @@ def _build_check(
         "properties": properties or {},
         "tags": tags if tags is not None else ["dbt"],
         "additional_metadata": {
-            "_qualytics_check_uid": dbt_check_uid(unique_id),
+            "_qualytics_check_uid": dbt_check_uid(unique_id, uid_suffix),
             "dbt_unique_id": unique_id,
             **(extra_metadata or {}),
         },
@@ -426,15 +471,14 @@ def convert_manifest(
                 node, unique_id, container, default_coverage, tags, include_status
             )
 
-        if converted:
-            out.append(converted)
+        out.extend(converted)
 
     return out
 
 
 def _convert_generic(
     node, unique_id, meta, models, container, coverage, tags, include_status
-) -> ConvertedCheck:
+) -> list[ConvertedCheck]:
     namespace = meta.get("namespace")
     name = meta.get("name") or ""
     key = f"{namespace}.{name}" if namespace else name
@@ -445,27 +489,65 @@ def _convert_generic(
     column = node.get("column_name") or kwargs.get("column_name")
     fields = [column] if column else []
 
+    def _unmapped(reason: str) -> list[ConvertedCheck]:
+        """Fallback so a test is never dropped, only downgraded to manual."""
+        return [
+            ConvertedCheck(
+                _build_check(
+                    rule_type="satisfiesExpression",
+                    container=container,
+                    fields=fields,
+                    description=f"[dbt] {key} — {reason}, author the expression by hand",
+                    unique_id=unique_id,
+                    tier=TIER_MANUAL,
+                    properties={"expression": ""},
+                    coverage=coverage,
+                    tags=tags,
+                    extra_metadata={"dbt_test": key},
+                    include_status=include_status,
+                ),
+                TIER_MANUAL,
+                key,
+                container,
+                reason,
+            )
+        ]
+
     if mapping is None:
         # Unrecognized generic test — still migrates, as a Draft for a human.
-        return ConvertedCheck(
-            _build_check(
-                rule_type="satisfiesExpression",
-                container=container,
-                fields=fields,
-                description=f"[dbt] {key} — unrecognized dbt test, author the expression by hand",
-                unique_id=unique_id,
-                tier=TIER_MANUAL,
-                properties={"expression": ""},
-                coverage=coverage,
-                tags=tags,
-                extra_metadata={"dbt_test": key},
-                include_status=include_status,
-            ),
-            TIER_MANUAL,
-            key,
-            container,
-            "unrecognized dbt test",
-        )
+        return _unmapped("unrecognized dbt test")
+
+    # A dbt test that asserts two things becomes two checks, each with its own
+    # UID suffix. A half whose bound is absent is skipped, not emitted null.
+    if mapping.splits:
+        out = []
+        for split in mapping.splits:
+            props = split.props(kwargs)
+            if props is None:
+                continue
+            out.append(
+                ConvertedCheck(
+                    _build_check(
+                        rule_type=split.rule_type,
+                        container=container,
+                        fields=fields,
+                        description=f"[dbt] {key} → {split.rule_type}",
+                        unique_id=unique_id,
+                        tier=mapping.tier,
+                        properties=props,
+                        coverage=coverage,
+                        tags=tags,
+                        extra_metadata={"dbt_test": key},
+                        include_status=include_status,
+                        uid_suffix=split.rule_type,
+                    ),
+                    mapping.tier,
+                    key,
+                    container,
+                    mapping.note,
+                )
+            )
+        return out or _unmapped("no bounds specified")
 
     properties = mapping.props(kwargs) if mapping.props else {}
 
@@ -487,30 +569,32 @@ def _convert_generic(
     if mapping.note:
         description += f" — {mapping.note}"
 
-    return ConvertedCheck(
-        _build_check(
-            rule_type=mapping.rule_type,
-            container=container,
-            fields=fields,
-            description=description,
-            unique_id=unique_id,
-            tier=mapping.tier,
-            properties=properties,
-            coverage=coverage,
-            tags=tags,
-            extra_metadata={"dbt_test": key},
-            include_status=include_status,
-        ),
-        mapping.tier,
-        key,
-        container,
-        mapping.note,
-    )
+    return [
+        ConvertedCheck(
+            _build_check(
+                rule_type=mapping.rule_type,
+                container=container,
+                fields=fields,
+                description=description,
+                unique_id=unique_id,
+                tier=mapping.tier,
+                properties=properties,
+                coverage=coverage,
+                tags=tags,
+                extra_metadata={"dbt_test": key},
+                include_status=include_status,
+            ),
+            mapping.tier,
+            key,
+            container,
+            mapping.note,
+        )
+    ]
 
 
 def _convert_singular(
     node, unique_id, container, coverage, tags, include_status
-) -> ConvertedCheck:
+) -> list[ConvertedCheck]:
     """Singular (bespoke SQL) test → satisfiesExpression in Draft.
 
     dbt compiles these to SQL that selects failing rows, which is not a row
@@ -526,34 +610,41 @@ def _convert_singular(
         "that is true for valid rows."
     )
 
-    return ConvertedCheck(
-        _build_check(
-            rule_type="satisfiesExpression",
-            container=container,
-            fields=[],
-            description=description,
-            unique_id=unique_id,
-            tier=TIER_MANUAL,
-            properties={"expression": ""},
-            coverage=coverage,
-            tags=tags,
-            extra_metadata={"dbt_test": name, "dbt_compiled_sql": sql}
-            if sql
-            else {"dbt_test": name},
-            include_status=include_status,
-        ),
-        TIER_MANUAL,
-        name,
-        container,
-        "singular SQL test",
-    )
+    return [
+        ConvertedCheck(
+            _build_check(
+                rule_type="satisfiesExpression",
+                container=container,
+                fields=[],
+                description=description,
+                unique_id=unique_id,
+                tier=TIER_MANUAL,
+                properties={"expression": ""},
+                coverage=coverage,
+                tags=tags,
+                extra_metadata={"dbt_test": name, "dbt_compiled_sql": sql}
+                if sql
+                else {"dbt_test": name},
+                include_status=include_status,
+            ),
+            TIER_MANUAL,
+            name,
+            container,
+            "singular SQL test",
+        )
+    ]
 
 
 # ── Reporting ─────────────────────────────────────────────────────────────
 
 
 def summarize(converted: list[ConvertedCheck]) -> dict:
-    """Coverage breakdown for `dbt plan`."""
+    """Coverage breakdown for `dbt plan`.
+
+    ``total`` counts emitted checks and ``dbt_tests`` counts source test nodes.
+    They differ when a split mapping turns one dbt test into two checks, so the
+    two are reported separately rather than conflated.
+    """
     total = len(converted)
     by_tier = {t: 0 for t in (TIER_DIRECT, TIER_NORMALIZE, TIER_MANUAL)}
     for c in converted:
@@ -562,9 +653,11 @@ def summarize(converted: list[ConvertedCheck]) -> dict:
     automatic = by_tier[TIER_DIRECT] + by_tier[TIER_NORMALIZE]
     containers = sorted({c.container for c in converted if c.container})
     missing_container = [c for c in converted if not c.container]
+    dbt_tests = {c.check["additional_metadata"]["dbt_unique_id"] for c in converted}
 
     return {
         "total": total,
+        "dbt_tests": len(dbt_tests),
         "direct": by_tier[TIER_DIRECT],
         "normalize": by_tier[TIER_NORMALIZE],
         "manual": by_tier[TIER_MANUAL],

--- a/tests/test_dbt.py
+++ b/tests/test_dbt.py
@@ -10,8 +10,10 @@ from qualytics.services.dbt import (
     container_name_for,
     convert_manifest,
     dbt_check_uid,
+    dbt_metadata,
     index_models,
     summarize,
+    row_filter,
     to_checks,
 )
 from qualytics.services.quality_checks import _UID_KEY, _build_create_payload
@@ -386,6 +388,128 @@ class TestNothingDropped:
             meta = c.check["additional_metadata"]
             assert meta["dbt_unique_id"].startswith("test.")
             assert meta[_UID_KEY].startswith("dbt__")
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# 3b. dbt `where` → Qualytics `filter`, and metadata capture
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def _configured_manifest(config, *, kwargs=None, singular=False):
+    model = f"model.{PKG}.stg_orders"
+    if singular:
+        uid, node = _singular_test(model, "stg_orders", "assert_thing")
+    else:
+        uid, node = _generic_test(
+            model, "stg_orders", "not_null", column="order_id", kwargs=kwargs
+        )
+    node["config"] = config
+    return {"nodes": {model: _model("stg_orders"), uid: node}}
+
+
+class TestFilterMapping:
+    def test_where_becomes_filter(self):
+        """Dropping `where` would fire the check on rows dbt excluded."""
+        converted = convert_manifest(
+            _configured_manifest({"where": "status != 'deleted'"})
+        )
+        assert converted[0].check["filter"] == "status != 'deleted'"
+
+    def test_filter_key_present_even_when_unset(self, manifest):
+        """Matches the shape strip_for_export produces."""
+        for c in convert_manifest(manifest):
+            assert "filter" in c.check
+            assert c.check["filter"] is None
+
+    def test_where_applies_to_singular_tests(self):
+        converted = convert_manifest(
+            _configured_manifest({"where": "amount > 0"}, singular=True)
+        )
+        assert converted[0].check["filter"] == "amount > 0"
+
+    def test_where_applies_to_split_checks(self):
+        model = f"model.{PKG}.dim_product"
+        uid, node = _generic_test(
+            model,
+            "dim_product",
+            "expect_column_value_lengths_to_be_between",
+            namespace="dbt_expectations",
+            column="sku",
+            kwargs={"min_value": 8, "max_value": 12},
+        )
+        node["config"] = {"where": "sku is not null"}
+        converted = convert_manifest(
+            {"nodes": {model: _model("dim_product"), uid: node}}
+        )
+        assert len(converted) == 2
+        assert all(c.check["filter"] == "sku is not null" for c in converted)
+
+    def test_empty_where_stays_none(self):
+        converted = convert_manifest(_configured_manifest({"where": ""}))
+        assert converted[0].check["filter"] is None
+
+    def test_row_filter_helper(self):
+        assert row_filter({"config": {"where": "x = 1"}}) == "x = 1"
+        assert row_filter({"config": {}}) is None
+        assert row_filter({}) is None
+
+
+class TestMetadataCapture:
+    def test_unconsumed_kwargs_are_recorded(self):
+        """A reviewer must not have to reopen the dbt project for a threshold."""
+        converted = convert_manifest(
+            _configured_manifest({}, kwargs={"at_least": 0.95, "group_by": ["region"]})
+        )
+        kwargs = converted[0].check["additional_metadata"]["dbt_kwargs"]
+        assert kwargs == {"at_least": 0.95, "group_by": ["region"]}
+
+    def test_column_name_is_not_echoed_into_metadata(self):
+        converted = convert_manifest(_configured_manifest({}))
+        assert "dbt_kwargs" not in converted[0].check["additional_metadata"]
+
+    def test_package_recorded(self, manifest):
+        node = next(
+            n for n in manifest["nodes"].values() if n.get("resource_type") == "test"
+        )
+        node["package_name"] = "acme_analytics"
+        converted = convert_manifest(manifest)
+        assert any(
+            c.check["additional_metadata"].get("dbt_package") == "acme_analytics"
+            for c in converted
+        )
+
+    def test_non_default_severity_recorded(self):
+        converted = convert_manifest(_configured_manifest({"severity": "warn"}))
+        assert converted[0].check["additional_metadata"]["dbt_severity"] == "warn"
+
+    def test_default_severity_omitted(self):
+        converted = convert_manifest(_configured_manifest({"severity": "error"}))
+        assert "dbt_severity" not in converted[0].check["additional_metadata"]
+
+    def test_tags_recorded(self):
+        converted = convert_manifest(_configured_manifest({"tags": ["nightly", "pii"]}))
+        assert converted[0].check["additional_metadata"]["dbt_tags"] == [
+            "nightly",
+            "pii",
+        ]
+
+    def test_extra_config_recorded(self):
+        converted = convert_manifest(
+            _configured_manifest({"limit": 500, "store_failures": True})
+        )
+        meta = converted[0].check["additional_metadata"]
+        assert meta["dbt_limit"] == 500
+        assert meta["dbt_store_failures"] is True
+
+    def test_metadata_helper_on_bare_node(self):
+        assert dbt_metadata({}, "not_null") == {"dbt_test": "not_null"}
+
+    def test_uid_and_provenance_survive_metadata_merge(self, manifest):
+        for c in convert_manifest(manifest):
+            meta = c.check["additional_metadata"]
+            assert meta[_UID_KEY].startswith("dbt__")
+            assert meta["dbt_unique_id"].startswith("test.")
+            assert meta["dbt_test"]
 
 
 # ══════════════════════════════════════════════════════════════════════════

--- a/tests/test_dbt.py
+++ b/tests/test_dbt.py
@@ -12,6 +12,7 @@ from qualytics.services.dbt import (
     dbt_check_uid,
     dbt_metadata,
     index_models,
+    resolve_check_fields,
     summarize,
     row_filter,
     to_checks,
@@ -651,3 +652,79 @@ class TestSummarize:
         s = summarize(convert_manifest({"nodes": {}}))
         assert s["total"] == 0
         assert s["automatic_pct"] == 0
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# 8. Field validation against the catalogue
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def _check(container="orders", fields=None):
+    return {
+        "rule_type": "notNull",
+        "container": container,
+        "fields": list(fields) if fields is not None else ["order_id"],
+        "properties": {},
+    }
+
+
+class TestResolveCheckFields:
+    def test_exact_match_passes_through(self):
+        ok, bad, fixed = resolve_check_fields(
+            [_check()], {"orders": ["order_id", "status"]}
+        )
+        assert len(ok) == 1 and not bad and not fixed
+        assert ok[0]["fields"] == ["order_id"]
+
+    def test_case_mismatch_is_corrected_to_catalogue_casing(self):
+        """Snowflake uppercases identifiers; the catalogue is ground truth."""
+        ok, bad, fixed = resolve_check_fields(
+            [_check(fields=["order_id"])], {"orders": ["ORDER_ID"]}
+        )
+        assert ok[0]["fields"] == ["ORDER_ID"]
+        assert fixed == ["orders.order_id → ORDER_ID"]
+        assert not bad
+
+    def test_unknown_field_is_rejected_with_a_reason(self):
+        ok, bad, _ = resolve_check_fields(
+            [_check(fields=["nope"])], {"orders": ["order_id"]}
+        )
+        assert not ok
+        assert len(bad) == 1
+        assert "nope" in bad[0]["reason"]
+        assert "orders" in bad[0]["reason"]
+
+    def test_partial_miss_rejects_the_whole_check(self):
+        ok, bad, _ = resolve_check_fields(
+            [_check(fields=["order_id", "ghost"])], {"orders": ["order_id"]}
+        )
+        assert not ok and len(bad) == 1
+        assert "ghost" in bad[0]["reason"]
+        assert "order_id" not in bad[0]["reason"].split(":")[-1]
+
+    def test_unknown_container_passes_through_untouched(self):
+        """The importer reports unknown containers; this must not pre-empt it."""
+        ok, bad, fixed = resolve_check_fields([_check(container="ghost")], {})
+        assert len(ok) == 1 and not bad and not fixed
+        assert ok[0]["fields"] == ["order_id"]
+
+    def test_container_level_check_with_no_fields_is_fine(self):
+        ok, bad, _ = resolve_check_fields([_check(fields=[])], {"orders": ["order_id"]})
+        assert len(ok) == 1 and not bad
+
+    def test_multi_field_check_resolves_each(self):
+        ok, _, fixed = resolve_check_fields(
+            [_check(fields=["a", "B"])], {"orders": ["A", "b"]}
+        )
+        assert ok[0]["fields"] == ["A", "b"]
+        assert len(fixed) == 2
+
+    def test_original_check_is_not_mutated(self):
+        original = _check(fields=["order_id"])
+        resolve_check_fields([original], {"orders": ["ORDER_ID"]})
+        assert original["fields"] == ["order_id"]
+
+    def test_empty_catalogue_is_a_no_op(self):
+        checks = [_check(), _check(container="other")]
+        ok, bad, fixed = resolve_check_fields(checks, {})
+        assert len(ok) == 2 and not bad and not fixed

--- a/tests/test_dbt.py
+++ b/tests/test_dbt.py
@@ -874,3 +874,92 @@ class TestKwargProperties:
             "expect_column_values_to_be_between", column="a", kwargs={"min_value": 0}
         )[0]
         assert c.check["properties"] == {"min": 0, "inclusive_min": True}
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# 11. Review findings — semantics that must not silently change
+# ══════════════════════════════════════════════════════════════════════════
+
+
+class TestSumSemantics:
+    """dataplane evaluates `sum` as hasSum(field, _ == value): equality, not a range."""
+
+    def test_sum_range_does_not_become_equality(self):
+        c = _one(
+            "expect_column_sum_to_be_between",
+            column="amount",
+            kwargs={"min_value": 100, "max_value": 500},
+        )[0]
+        assert c.check["rule_type"] != "sum", "sum == 100 would flag valid data"
+        assert c.tier == TIER_MANUAL
+        assert c.check["additional_metadata"]["dbt_kwargs"]["max_value"] == 500
+
+    def test_degenerate_range_converts_to_sum(self):
+        c = _one(
+            "expect_column_sum_to_be_between",
+            column="amount",
+            kwargs={"min_value": 100, "max_value": 100},
+        )[0]
+        assert c.check["rule_type"] == "sum"
+        assert c.check["properties"] == {"value": 100}
+
+    def test_one_sided_sum_is_not_converted(self):
+        c = _one(
+            "expect_column_sum_to_be_between",
+            column="amount",
+            kwargs={"min_value": 100},
+        )[0]
+        assert c.check["rule_type"] == "satisfiesExpression"
+
+    def test_unconvertible_test_is_still_emitted(self):
+        """Falling back must never mean dropping the test."""
+        converted = _one(
+            "expect_column_sum_to_be_between",
+            column="amount",
+            kwargs={"min_value": 1, "max_value": 2},
+        )
+        assert len(converted) == 1
+        assert converted[0].check["additional_metadata"]["dbt_unique_id"]
+
+
+class TestCrossReferenceResolution:
+    """A referenced container must resolve exactly like the check's own."""
+
+    def _rel_manifest(self):
+        orders = f"model.{PKG}.stg_orders"
+        customers = f"model.{PKG}.stg_customers"
+        uid, node = _generic_test(
+            orders,
+            "stg_orders",
+            "relationships",
+            column="customer_id",
+            kwargs={"to": "ref('stg_customers')", "field": "customer_id"},
+            extra_deps=[customers],
+        )
+        return {
+            "nodes": {
+                orders: _model("stg_orders"),
+                customers: _model("stg_customers"),
+                uid: node,
+            }
+        }
+
+    def test_container_case_applies_to_the_reference(self):
+        c = convert_manifest(self._rel_manifest(), container_case="upper")[0]
+        assert c.check["container"] == "STG_ORDERS"
+        assert c.check["properties"]["ref_container_name"] == "STG_CUSTOMERS"
+
+    def test_container_map_applies_to_the_reference(self):
+        c = convert_manifest(
+            self._rel_manifest(), container_map={"stg_customers": "CUSTOMERS_RAW"}
+        )[0]
+        assert c.check["properties"]["ref_container_name"] == "CUSTOMERS_RAW"
+
+    def test_both_sides_resolve_independently(self):
+        c = convert_manifest(
+            self._rel_manifest(),
+            container_map={"stg_orders": "ORDERS_A"},
+            container_case="upper",
+        )[0]
+        assert c.check["container"] == "ORDERS_A"
+        assert c.check["properties"]["ref_container_name"] == "STG_CUSTOMERS"

--- a/tests/test_dbt.py
+++ b/tests/test_dbt.py
@@ -1,0 +1,399 @@
+"""Tests for dbt manifest → quality check conversion."""
+
+import pytest
+
+from qualytics.services.dbt import (
+    DBT_RULE_MAP,
+    TIER_DIRECT,
+    TIER_MANUAL,
+    TIER_NORMALIZE,
+    container_name_for,
+    convert_manifest,
+    dbt_check_uid,
+    index_models,
+    summarize,
+    to_checks,
+)
+from qualytics.services.quality_checks import _UID_KEY, _build_create_payload
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+PKG = "jaffle_analytics"
+
+
+def _model(name, *, alias=None, schema="analytics"):
+    return {
+        "resource_type": "model",
+        "name": name,
+        "alias": alias or name,
+        "schema": schema,
+        "database": "warehouse",
+    }
+
+
+def _generic_test(
+    model_uid,
+    model_name,
+    test_name,
+    *,
+    namespace=None,
+    column=None,
+    kwargs=None,
+    extra_deps=None,
+):
+    key = f"{namespace}.{test_name}" if namespace else test_name
+    suffix = f"{column or 'tbl'}"
+    unique_id = f"test.{PKG}.{key.replace('.', '_')}_{model_name}_{suffix}.a1b2c3"
+    deps = [model_uid] + list(extra_deps or [])
+    return unique_id, {
+        "resource_type": "test",
+        "name": f"{key}_{model_name}_{suffix}",
+        "column_name": column,
+        "attached_node": model_uid,
+        "file_key_name": f"models.{model_name}",
+        "depends_on": {"nodes": deps},
+        "test_metadata": {
+            "namespace": namespace,
+            "name": test_name,
+            "kwargs": {**({"column_name": column} if column else {}), **(kwargs or {})},
+        },
+    }
+
+
+def _singular_test(model_uid, model_name, name, sql="select * from x where 1=0"):
+    unique_id = f"test.{PKG}.{name}.deadbee"
+    return unique_id, {
+        "resource_type": "test",
+        "name": name,
+        "attached_node": model_uid,
+        "file_key_name": f"models.{model_name}",
+        "depends_on": {"nodes": [model_uid]},
+        "compiled_code": sql,
+    }
+
+
+@pytest.fixture
+def manifest():
+    """A manifest shaped like real dbt output: models + tests, aliases, singulars."""
+    orders = f"model.{PKG}.stg_orders"
+    customers = f"model.{PKG}.stg_customers"
+    revenue = f"model.{PKG}.fct_revenue"
+
+    nodes = {
+        orders: _model("stg_orders", alias="stg_orders_v2"),
+        customers: _model("stg_customers"),
+        revenue: _model("fct_revenue"),
+    }
+
+    for uid, node in [
+        _generic_test(orders, "stg_orders", "not_null", column="order_id"),
+        _generic_test(orders, "stg_orders", "unique", column="order_id"),
+        _generic_test(
+            orders,
+            "stg_orders",
+            "accepted_values",
+            column="status",
+            kwargs={"values": ["placed", "shipped"]},
+        ),
+        _generic_test(
+            orders,
+            "stg_orders",
+            "relationships",
+            column="customer_id",
+            kwargs={"to": "ref('stg_customers')", "field": "customer_id"},
+            extra_deps=[customers],
+        ),
+        _generic_test(
+            orders,
+            "stg_orders",
+            "accepted_range",
+            namespace="dbt_utils",
+            column="amount",
+            kwargs={"min_value": 0, "max_value": 5000},
+        ),
+        _generic_test(
+            revenue,
+            "fct_revenue",
+            "expect_column_values_to_match_regex",
+            namespace="dbt_expectations",
+            column="currency",
+            kwargs={"regex": "^[A-Z]{3}$"},
+        ),
+        _generic_test(
+            revenue,
+            "fct_revenue",
+            "expect_table_row_count_to_be_between",
+            namespace="dbt_expectations",
+            kwargs={"min_value": 1000},
+        ),
+        _generic_test(
+            revenue,
+            "fct_revenue",
+            "is_valid_iso_currency",
+            namespace="mycompany",
+            column="currency_code",
+        ),
+        # Two singular tests on the SAME model — the collision case.
+        _singular_test(revenue, "fct_revenue", "assert_revenue_reconciles"),
+        _singular_test(revenue, "fct_revenue", "assert_no_orphan_refunds"),
+    ]:
+        nodes[uid] = node
+
+    return {"nodes": nodes}
+
+
+def _by_dbt_test(converted, name):
+    return next(c for c in converted if c.dbt_test == name)
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# 1. UID — the invariant that prevents silent test loss
+# ══════════════════════════════════════════════════════════════════════════
+
+
+class TestCheckUID:
+    def test_derived_from_unique_id(self):
+        uid = dbt_check_uid("test.jaffle.not_null_orders_order_id.5fb5b8f")
+        assert uid == "dbt__test_jaffle_not_null_orders_order_id_5fb5b8f"
+
+    def test_every_check_has_a_distinct_uid(self, manifest):
+        converted = convert_manifest(manifest)
+        uids = [c.check["additional_metadata"][_UID_KEY] for c in converted]
+        assert len(uids) == len(set(uids)), "UID collision would silently drop checks"
+
+    def test_two_singular_tests_on_one_model_do_not_collide(self, manifest):
+        """The case the CLI's own container__rule__fields scheme collapses."""
+        converted = convert_manifest(manifest)
+        singular = [c for c in converted if c.note == "singular SQL test"]
+        assert len(singular) == 2
+        uids = {c.check["additional_metadata"][_UID_KEY] for c in singular}
+        assert len(uids) == 2
+
+    def test_one_dbt_test_yields_exactly_one_check(self, manifest):
+        test_nodes = [
+            n for n in manifest["nodes"].values() if n.get("resource_type") == "test"
+        ]
+        assert len(convert_manifest(manifest)) == len(test_nodes)
+
+    def test_conversion_is_deterministic(self, manifest):
+        assert to_checks(convert_manifest(manifest)) == to_checks(
+            convert_manifest(manifest)
+        )
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# 2. Rule + property mapping
+# ══════════════════════════════════════════════════════════════════════════
+
+
+class TestRuleMapping:
+    def test_not_null_is_direct(self, manifest):
+        c = _by_dbt_test(convert_manifest(manifest), "not_null")
+        assert c.check["rule_type"] == "notNull"
+        assert c.tier == TIER_DIRECT
+        assert c.check["fields"] == ["order_id"]
+
+    def test_accepted_values_uses_list_property(self, manifest):
+        """controlplane QualityCheckProperties calls it `list`, not `list_of_values`."""
+        c = _by_dbt_test(convert_manifest(manifest), "accepted_values")
+        assert c.check["rule_type"] == "expectedValues"
+        assert c.check["properties"] == {"list": ["placed", "shipped"]}
+
+    def test_accepted_range_maps_min_max_not_min_value(self, manifest):
+        """dbt says min_value/max_value; Qualytics `between` says min/max."""
+        c = _by_dbt_test(convert_manifest(manifest), "dbt_utils.accepted_range")
+        assert c.check["rule_type"] == "between"
+        assert c.check["properties"] == {"min": 0, "max": 5000}
+
+    def test_regex_maps_to_pattern(self, manifest):
+        c = _by_dbt_test(
+            convert_manifest(manifest),
+            "dbt_expectations.expect_column_values_to_match_regex",
+        )
+        assert c.check["rule_type"] == "matchesPattern"
+        assert c.check["properties"] == {"pattern": "^[A-Z]{3}$"}
+
+    def test_relationships_carries_ref_container_name(self, manifest):
+        c = _by_dbt_test(convert_manifest(manifest), "relationships")
+        assert c.check["rule_type"] == "existsIn"
+        assert c.check["properties"]["ref_container_name"] == "stg_customers"
+
+    def test_container_level_rule_has_no_fields(self, manifest):
+        c = _by_dbt_test(
+            convert_manifest(manifest),
+            "dbt_expectations.expect_table_row_count_to_be_between",
+        )
+        assert c.check["rule_type"] == "volumetric"
+        assert c.check["fields"] == []
+
+    def test_every_mapping_targets_a_known_rule_type(self):
+        # Mirrors controlplane app/types/rule_types.py RuleType.
+        known = {
+            "notNull",
+            "unique",
+            "expectedValues",
+            "existsIn",
+            "between",
+            "satisfiesExpression",
+            "distinctCount",
+            "matchesPattern",
+            "maxLength",
+            "minLength",
+            "isType",
+            "maxValue",
+            "minValue",
+            "metric",
+            "sum",
+            "volumetric",
+            "freshness",
+            "fieldCount",
+            "expectedSchema",
+        }
+        for key, mapping in DBT_RULE_MAP.items():
+            assert mapping.rule_type in known, (
+                f"{key} → unknown rule {mapping.rule_type}"
+            )
+
+    def test_every_mapping_has_a_valid_tier(self):
+        for key, mapping in DBT_RULE_MAP.items():
+            assert mapping.tier in (TIER_DIRECT, TIER_NORMALIZE, TIER_MANUAL), key
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# 3. Nothing is dropped
+# ══════════════════════════════════════════════════════════════════════════
+
+
+class TestNothingDropped:
+    def test_unrecognized_generic_test_still_converts(self, manifest):
+        c = _by_dbt_test(convert_manifest(manifest), "mycompany.is_valid_iso_currency")
+        assert c.check["rule_type"] == "satisfiesExpression"
+        assert c.tier == TIER_MANUAL
+        assert c.check["status"] == "Draft"
+
+    def test_singular_test_carries_compiled_sql(self, manifest):
+        converted = convert_manifest(manifest)
+        c = _by_dbt_test(converted, "assert_revenue_reconciles")
+        assert c.check["rule_type"] == "satisfiesExpression"
+        assert c.check["additional_metadata"]["dbt_compiled_sql"]
+
+    def test_provenance_is_recorded(self, manifest):
+        for c in convert_manifest(manifest):
+            meta = c.check["additional_metadata"]
+            assert meta["dbt_unique_id"].startswith("test.")
+            assert meta[_UID_KEY].startswith("dbt__")
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# 4. Container resolution
+# ══════════════════════════════════════════════════════════════════════════
+
+
+class TestContainerResolution:
+    def test_alias_wins_over_name(self, manifest):
+        c = _by_dbt_test(convert_manifest(manifest), "not_null")
+        assert c.check["container"] == "stg_orders_v2"
+
+    def test_container_map_override(self, manifest):
+        converted = convert_manifest(
+            manifest, container_map={"stg_orders": "ORDERS_RAW"}
+        )
+        assert _by_dbt_test(converted, "not_null").check["container"] == "ORDERS_RAW"
+
+    def test_container_case_upper(self, manifest):
+        converted = convert_manifest(manifest, container_case="upper")
+        assert _by_dbt_test(converted, "not_null").check["container"] == "STG_ORDERS_V2"
+
+    def test_relationships_attaches_to_the_right_model(self, manifest):
+        """A relationships test depends on two models; it must attach to its own."""
+        c = _by_dbt_test(convert_manifest(manifest), "relationships")
+        assert c.check["container"] == "stg_orders_v2"
+        assert c.check["properties"]["ref_container_name"] == "stg_customers"
+
+    def test_index_models_ignores_tests(self, manifest):
+        assert all("model." in uid for uid in index_models(manifest))
+
+    def test_container_name_prefers_alias(self):
+        assert container_name_for({"name": "a", "alias": "b"}) == "b"
+        assert container_name_for({"name": "a"}) == "a"
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# 5. Status / re-sync behavior
+# ══════════════════════════════════════════════════════════════════════════
+
+
+class TestStatus:
+    def test_direct_lands_active(self, manifest):
+        assert (
+            _by_dbt_test(convert_manifest(manifest), "not_null").check["status"]
+            == "Active"
+        )
+
+    def test_normalize_and_manual_land_draft(self, manifest):
+        converted = convert_manifest(manifest)
+        for c in converted:
+            if c.tier in (TIER_NORMALIZE, TIER_MANUAL):
+                assert c.check["status"] == "Draft", c.dbt_test
+
+    def test_include_status_false_omits_the_key(self, manifest):
+        """Re-sync must not reset a check a human activated in the product."""
+        for c in convert_manifest(manifest, include_status=False):
+            assert "status" not in c.check
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# 6. Interop with the existing import path
+# ══════════════════════════════════════════════════════════════════════════
+
+
+class TestImportInterop:
+    def test_checks_build_a_valid_create_payload(self, manifest):
+        for check in to_checks(convert_manifest(manifest)):
+            payload = _build_create_payload(check, container_id=42)
+            assert payload["container_id"] == 42
+            assert payload["rule"] == check["rule_type"]
+            assert payload["additional_metadata"][_UID_KEY].startswith("dbt__")
+
+    def test_portable_shape_has_the_expected_keys(self, manifest):
+        required = {
+            "rule_type",
+            "description",
+            "container",
+            "fields",
+            "coverage",
+            "properties",
+            "tags",
+            "additional_metadata",
+            "status",
+        }
+        for check in to_checks(convert_manifest(manifest)):
+            assert required <= set(check)
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# 7. Reporting
+# ══════════════════════════════════════════════════════════════════════════
+
+
+class TestSummarize:
+    def test_counts_add_up(self, manifest):
+        s = summarize(convert_manifest(manifest))
+        assert s["total"] == 10
+        assert s["direct"] + s["normalize"] + s["manual"] == s["total"]
+        assert s["automatic"] == s["direct"] + s["normalize"]
+
+    def test_percentage(self, manifest):
+        s = summarize(convert_manifest(manifest))
+        assert s["automatic_pct"] == round(s["automatic"] / s["total"] * 100)
+
+    def test_containers_listed(self, manifest):
+        s = summarize(convert_manifest(manifest))
+        assert "stg_orders_v2" in s["containers"]
+        assert s["unresolved_containers"] == 0
+
+    def test_empty_manifest(self):
+        s = summarize(convert_manifest({"nodes": {}}))
+        assert s["total"] == 0
+        assert s["automatic_pct"] == 0

--- a/tests/test_dbt.py
+++ b/tests/test_dbt.py
@@ -445,6 +445,28 @@ class TestStatus:
         for c in convert_manifest(manifest, include_status=False):
             assert "status" not in c.check
 
+    def test_status_override_forces_draft(self, manifest):
+        for c in convert_manifest(manifest, status_override="Draft"):
+            assert c.check["status"] == "Draft"
+
+    def test_status_override_forces_active(self, manifest):
+        """The tiers are a recommendation; the caller owns the migration."""
+        for c in convert_manifest(manifest, status_override="Active"):
+            assert c.check["status"] == "Active"
+
+    def test_status_override_does_not_change_tiers(self, manifest):
+        """Overriding status must not rewrite the reported crosswalk."""
+        default = summarize(convert_manifest(manifest))
+        forced = summarize(convert_manifest(manifest, status_override="Active"))
+        assert default["direct"] == forced["direct"]
+        assert default["manual"] == forced["manual"]
+
+    def test_status_override_wins_over_include_status(self, manifest):
+        converted = convert_manifest(
+            manifest, include_status=False, status_override="Draft"
+        )
+        assert all(c.check["status"] == "Draft" for c in converted)
+
 
 # ══════════════════════════════════════════════════════════════════════════
 # 6. Interop with the existing import path

--- a/tests/test_dbt.py
+++ b/tests/test_dbt.py
@@ -220,7 +220,12 @@ class TestRuleMapping:
         """dbt says min_value/max_value; Qualytics `between` says min/max."""
         c = _by_dbt_test(convert_manifest(manifest), "dbt_utils.accepted_range")
         assert c.check["rule_type"] == "between"
-        assert c.check["properties"] == {"min": 0, "max": 5000}
+        assert c.check["properties"] == {
+            "min": 0,
+            "inclusive_min": True,
+            "max": 5000,
+            "inclusive_max": True,
+        }
 
     def test_regex_maps_to_pattern(self, manifest):
         c = _by_dbt_test(
@@ -728,3 +733,144 @@ class TestResolveCheckFields:
         checks = [_check(), _check(container="other")]
         ok, bad, fixed = resolve_check_fields(checks, {})
         assert len(ok) == 2 and not bad and not fixed
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# 9. Rule contract — fields / filter / coverage per rule type
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def _one(
+    test_name, *, namespace="dbt_expectations", column=None, kwargs=None, config=None
+):
+    model = f"model.{PKG}.orders"
+    uid, node = _generic_test(
+        model, "orders", test_name, namespace=namespace, column=column, kwargs=kwargs
+    )
+    if config:
+        node["config"] = config
+    converted = convert_manifest({"nodes": {model: _model("orders"), uid: node}})
+    return converted
+
+
+class TestRuleContract:
+    def test_container_level_rule_takes_no_filter(self):
+        """volumetric is filterable: False — a where clause must not be attached."""
+        c = _one(
+            "expect_table_row_count_to_be_between",
+            kwargs={"min_value": 10},
+            config={"where": "x = 1"},
+        )[0]
+        assert c.check["rule_type"] == "volumetric"
+        assert c.check["filter"] is None
+
+    def test_filterable_rule_keeps_its_filter(self):
+        c = _one(
+            "expect_column_values_to_not_be_null", column="a", config={"where": "x = 1"}
+        )[0]
+        assert c.check["filter"] == "x = 1"
+
+    def test_rules_without_coverage_support_send_none(self):
+        for name, kwargs in [
+            ("expect_table_row_count_to_be_between", {"min_value": 10}),
+            (
+                "expect_row_values_to_have_recent_data",
+                {"datepart": "day", "interval": 1},
+            ),
+        ]:
+            c = _one(name, kwargs=kwargs)[0]
+            assert c.check["coverage"] is None, name
+
+    def test_coverage_supporting_rule_keeps_it(self):
+        c = _one("expect_column_values_to_not_be_null", column="a")[0]
+        assert c.check["coverage"] == 1.0
+
+    def test_container_level_rule_has_empty_fields(self):
+        c = _one(
+            "expect_table_row_count_to_be_between", column="a", kwargs={"min_value": 10}
+        )[0]
+        assert c.check["fields"] == []
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# 10. Properties built from dbt kwargs
+# ══════════════════════════════════════════════════════════════════════════
+
+
+class TestKwargProperties:
+    def test_distinct_count_less_than(self):
+        c = _one(
+            "expect_column_distinct_count_to_be_less_than",
+            column="a",
+            kwargs={"value": 5},
+        )[0]
+        assert c.check["rule_type"] == "distinctCount"
+        assert c.check["properties"] == {"comparison": "less than", "value": 5}
+        assert c.tier == TIER_DIRECT
+
+    def test_distinct_count_equal(self):
+        c = _one(
+            "expect_column_distinct_count_to_equal", column="a", kwargs={"value": 3}
+        )[0]
+        assert c.check["properties"] == {"comparison": "equal to", "value": 3}
+
+    def test_not_constant_is_distinct_count_gt_one(self):
+        c = _one("not_constant", namespace="dbt_utils", column="a")[0]
+        assert c.check["properties"] == {"comparison": "greater than", "value": 1}
+        assert c.tier == TIER_DIRECT
+
+    def test_freshness_converts_datepart_to_milliseconds(self):
+        c = _one(
+            "expect_row_values_to_have_recent_data",
+            kwargs={"datepart": "day", "interval": 2},
+        )[0]
+        assert c.check["rule_type"] == "freshness"
+        assert c.check["properties"] == {"value": 172_800_000}
+        assert c.tier == TIER_DIRECT
+
+    def test_freshness_handles_hours_and_plurals(self):
+        c = _one(
+            "expect_row_values_to_have_recent_data",
+            kwargs={"datepart": "hours", "interval": 6},
+        )[0]
+        assert c.check["properties"] == {"value": 21_600_000}
+
+    def test_freshness_without_interval_stays_empty(self):
+        c = _one("expect_row_values_to_have_recent_data", kwargs={"datepart": "day"})[0]
+        assert c.check["properties"] == {}
+
+    def test_volumetric_gets_comparison_and_window(self):
+        c = _one(
+            "expect_table_row_count_to_be_between",
+            kwargs={"min_value": 1000, "max_value": 50000},
+        )[0]
+        props = c.check["properties"]
+        assert props["comparison"] == "Absolute Value"
+        assert props["window_size"] == 1
+        assert props["min"] == 1000 and props["max"] == 50000
+        assert c.tier == TIER_NORMALIZE, "window is assumed, so it stays reviewable"
+
+    def test_expected_schema_lists_the_column(self):
+        c = _one("expect_column_to_exist", column="sku")[0]
+        assert c.check["rule_type"] == "expectedSchema"
+        assert c.check["properties"] == {"list": ["sku"], "allow_other_fields": True}
+
+    def test_metric_gets_a_comparison(self):
+        c = _one(
+            "expect_column_mean_to_be_between",
+            column="amount",
+            kwargs={"min_value": 1, "max_value": 9},
+        )[0]
+        assert c.check["properties"]["comparison"] == "Absolute Value"
+        assert c.check["properties"]["min"] == 1
+
+    def test_relationships_carries_the_referenced_field(self, manifest):
+        c = _by_dbt_test(convert_manifest(manifest), "relationships")
+        assert c.check["properties"]["field_name"] == "customer_id"
+        assert c.check["properties"]["ref_container_name"] == "stg_customers"
+
+    def test_one_sided_range_does_not_fabricate_the_other_bound(self):
+        c = _one(
+            "expect_column_values_to_be_between", column="a", kwargs={"min_value": 0}
+        )[0]
+        assert c.check["properties"] == {"min": 0, "inclusive_min": True}

--- a/tests/test_dbt.py
+++ b/tests/test_dbt.py
@@ -134,6 +134,15 @@ def manifest():
             namespace="mycompany",
             column="currency_code",
         ),
+        # Splits into minLength + maxLength.
+        _generic_test(
+            revenue,
+            "fct_revenue",
+            "expect_column_value_lengths_to_be_between",
+            namespace="dbt_expectations",
+            column="sku",
+            kwargs={"min_value": 8, "max_value": 12},
+        ),
         # Two singular tests on the SAME model — the collision case.
         _singular_test(revenue, "fct_revenue", "assert_revenue_reconciles"),
         _singular_test(revenue, "fct_revenue", "assert_no_orphan_refunds"),
@@ -170,11 +179,15 @@ class TestCheckUID:
         uids = {c.check["additional_metadata"][_UID_KEY] for c in singular}
         assert len(uids) == 2
 
-    def test_one_dbt_test_yields_exactly_one_check(self, manifest):
+    def test_every_dbt_test_yields_at_least_one_check(self, manifest):
+        """Split mappings emit two; nothing may emit zero."""
         test_nodes = [
             n for n in manifest["nodes"].values() if n.get("resource_type") == "test"
         ]
-        assert len(convert_manifest(manifest)) == len(test_nodes)
+        converted = convert_manifest(manifest)
+        sources = {c.check["additional_metadata"]["dbt_unique_id"] for c in converted}
+        assert len(sources) == len(test_nodes)
+        assert len(converted) >= len(test_nodes)
 
     def test_conversion_is_deterministic(self, manifest):
         assert to_checks(convert_manifest(manifest)) == to_checks(
@@ -258,6 +271,96 @@ class TestRuleMapping:
     def test_every_mapping_has_a_valid_tier(self):
         for key, mapping in DBT_RULE_MAP.items():
             assert mapping.tier in (TIER_DIRECT, TIER_NORMALIZE, TIER_MANUAL), key
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# 2b. Split mappings — one dbt test asserting two things
+# ══════════════════════════════════════════════════════════════════════════
+
+
+LENGTHS_BETWEEN = "dbt_expectations.expect_column_value_lengths_to_be_between"
+LENGTHS_EQUAL = "dbt_expectations.expect_column_value_lengths_to_equal"
+
+
+def _lengths_manifest(kwargs, test_name="expect_column_value_lengths_to_be_between"):
+    model = f"model.{PKG}.dim_product"
+    uid, node = _generic_test(
+        model,
+        "dim_product",
+        test_name,
+        namespace="dbt_expectations",
+        column="sku",
+        kwargs=kwargs,
+    )
+    return {"nodes": {model: _model("dim_product"), uid: node}}
+
+
+class TestSplitMappings:
+    def test_lengths_between_emits_min_and_max(self, manifest):
+        checks = [
+            c for c in convert_manifest(manifest) if c.dbt_test == LENGTHS_BETWEEN
+        ]
+        assert len(checks) == 2
+        assert {c.check["rule_type"] for c in checks} == {"minLength", "maxLength"}
+
+    def test_split_properties_carry_the_right_bound(self, manifest):
+        checks = {
+            c.check["rule_type"]: c.check["properties"]
+            for c in convert_manifest(manifest)
+            if c.dbt_test == LENGTHS_BETWEEN
+        }
+        assert checks["minLength"] == {"value": 8}
+        assert checks["maxLength"] == {"value": 12}
+
+    def test_split_uids_are_suffixed_and_distinct(self, manifest):
+        checks = [
+            c for c in convert_manifest(manifest) if c.dbt_test == LENGTHS_BETWEEN
+        ]
+        uids = [c.check["additional_metadata"][_UID_KEY] for c in checks]
+        assert len(set(uids)) == 2
+        assert any(u.endswith("__minlength") for u in uids)
+        assert any(u.endswith("__maxlength") for u in uids)
+
+    def test_split_halves_share_dbt_provenance(self, manifest):
+        checks = [
+            c for c in convert_manifest(manifest) if c.dbt_test == LENGTHS_BETWEEN
+        ]
+        sources = {c.check["additional_metadata"]["dbt_unique_id"] for c in checks}
+        assert len(sources) == 1
+
+    def test_split_is_direct_not_draft(self, manifest):
+        for c in convert_manifest(manifest):
+            if c.dbt_test == LENGTHS_BETWEEN:
+                assert c.tier == TIER_DIRECT
+                assert c.check["status"] == "Active"
+
+    def test_min_only_emits_one_check(self):
+        converted = convert_manifest(_lengths_manifest({"min_value": 8}))
+        assert len(converted) == 1
+        assert converted[0].check["rule_type"] == "minLength"
+        assert converted[0].check["properties"] == {"value": 8}
+
+    def test_max_only_emits_one_check(self):
+        converted = convert_manifest(_lengths_manifest({"max_value": 12}))
+        assert len(converted) == 1
+        assert converted[0].check["rule_type"] == "maxLength"
+
+    def test_no_bounds_falls_back_to_manual(self):
+        """Never emit zero checks — downgrade to a Draft instead."""
+        converted = convert_manifest(_lengths_manifest({}))
+        assert len(converted) == 1
+        assert converted[0].check["rule_type"] == "satisfiesExpression"
+        assert converted[0].tier == TIER_MANUAL
+
+    def test_lengths_to_equal_pins_both_ends(self):
+        converted = convert_manifest(
+            _lengths_manifest(
+                {"value": 10}, test_name="expect_column_value_lengths_to_equal"
+            )
+        )
+        assert len(converted) == 2
+        props = {c.check["rule_type"]: c.check["properties"] for c in converted}
+        assert props == {"minLength": {"value": 10}, "maxLength": {"value": 10}}
 
 
 # ══════════════════════════════════════════════════════════════════════════
@@ -380,9 +483,14 @@ class TestImportInterop:
 class TestSummarize:
     def test_counts_add_up(self, manifest):
         s = summarize(convert_manifest(manifest))
-        assert s["total"] == 10
         assert s["direct"] + s["normalize"] + s["manual"] == s["total"]
         assert s["automatic"] == s["direct"] + s["normalize"]
+
+    def test_checks_and_dbt_tests_are_counted_separately(self, manifest):
+        """11 test nodes, one of which splits into minLength + maxLength."""
+        s = summarize(convert_manifest(manifest))
+        assert s["dbt_tests"] == 11
+        assert s["total"] == 12
 
     def test_percentage(self, manifest):
         s = summarize(convert_manifest(manifest))

--- a/tests/test_dbt_cli.py
+++ b/tests/test_dbt_cli.py
@@ -273,3 +273,83 @@ class TestDbtImport:
         self._run(cli_runner, manifest_file, ["--emit-yaml", str(out)])
         names = [n for _r, _d, ns in os.walk(out) for n in ns]
         assert len(names) == len(set(names)) == 2
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# Field validation wiring
+# ══════════════════════════════════════════════════════════════════════════
+
+
+class TestFieldValidation:
+    def _run(self, cli_runner, manifest_file, catalogue, extra=None):
+        """Run import with a stubbed field catalogue for container stg_orders."""
+        with (
+            patch("qualytics.cli.dbt.get_client", return_value=MagicMock()),
+            patch("qualytics.cli.dbt.get_table_ids", return_value={"stg_orders": 7}),
+            patch("qualytics.cli.dbt.container_field_names", return_value=catalogue),
+            patch(
+                "qualytics.cli.dbt.import_checks_to_datastore",
+                return_value={"created": 1, "updated": 0, "failed": 0, "errors": []},
+            ) as importer,
+        ):
+            res = cli_runner.invoke(
+                app,
+                ["dbt", "import", "--manifest", manifest_file, "--datastore-id", "1"]
+                + (extra or []),
+            )
+        return res, importer
+
+    def test_casing_is_corrected_from_the_catalogue(self, cli_runner, manifest_file):
+        res, importer = self._run(cli_runner, manifest_file, ["ORDER_ID"])
+        assert res.exit_code == 0
+        sent = importer.call_args[0][2]
+        assert ["ORDER_ID"] in [c["fields"] for c in sent if c["fields"]]
+        assert "order_id → ORDER_ID" in res.output
+
+    def test_unknown_field_is_rejected_and_counted(self, cli_runner, manifest_file):
+        res, importer = self._run(cli_runner, manifest_file, ["something_else"])
+        assert res.exit_code == 0
+        assert "not found in container 'stg_orders'" in res.output
+        # the notNull check is withheld; the singular test has no fields
+        sent = importer.call_args[0][2]
+        assert all(not c["fields"] for c in sent)
+
+    def test_rejected_checks_are_not_sent_to_the_importer(
+        self, cli_runner, manifest_file
+    ):
+        _, importer = self._run(cli_runner, manifest_file, ["nope"])
+        sent = importer.call_args[0][2]
+        assert len(sent) == 1  # only the fieldless singular check survives
+
+    def test_no_validate_fields_skips_lookup_entirely(self, cli_runner, manifest_file):
+        with (
+            patch("qualytics.cli.dbt.get_client", return_value=MagicMock()),
+            patch("qualytics.cli.dbt.get_table_ids") as table_ids,
+            patch(
+                "qualytics.cli.dbt.import_checks_to_datastore",
+                return_value={"created": 2, "updated": 0, "failed": 0, "errors": []},
+            ) as importer,
+        ):
+            res = cli_runner.invoke(
+                app,
+                [
+                    "dbt",
+                    "import",
+                    "--manifest",
+                    manifest_file,
+                    "--datastore-id",
+                    "1",
+                    "--no-validate-fields",
+                ],
+            )
+        assert res.exit_code == 0
+        table_ids.assert_not_called()
+        assert len(importer.call_args[0][2]) == 2
+
+    def test_exact_match_sends_fields_unchanged(self, cli_runner, manifest_file):
+        res, importer = self._run(cli_runner, manifest_file, ["order_id"])
+        assert res.exit_code == 0
+        assert "Corrected" not in res.output
+        assert ["order_id"] in [
+            c["fields"] for c in importer.call_args[0][2] if c["fields"]
+        ]

--- a/tests/test_dbt_cli.py
+++ b/tests/test_dbt_cli.py
@@ -232,7 +232,8 @@ class TestDbtImport:
         assert res.exit_code == 0
         assert importer.call_count == 2
 
-    def test_failures_exit_nonzero_with_guidance(self, cli_runner, manifest_file):
+    def test_failures_are_reported_without_failing(self, cli_runner, manifest_file):
+        """Matches `checks import`: per-check errors are printed, exit stays 0."""
         res, _ = self._run(
             cli_runner,
             manifest_file,
@@ -243,7 +244,8 @@ class TestDbtImport:
                 "errors": ["Container 'stg_orders' not found in datastore 1"],
             },
         )
-        assert res.exit_code == 1
+        assert res.exit_code == 0
+        assert "not found in datastore 1" in res.output
         assert "catalogued" in res.output
 
     def test_emit_yaml_writes_files(self, cli_runner, manifest_file, tmp_path):

--- a/tests/test_dbt_cli.py
+++ b/tests/test_dbt_cli.py
@@ -1,0 +1,246 @@
+"""Tests for the `qualytics dbt` command group."""
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from qualytics.qualytics import app
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+def _manifest_dict():
+    model = "model.jaffle.stg_orders"
+    return {
+        "nodes": {
+            model: {
+                "resource_type": "model",
+                "name": "stg_orders",
+                "alias": "stg_orders",
+                "schema": "analytics",
+            },
+            "test.jaffle.not_null_stg_orders_order_id.abc": {
+                "resource_type": "test",
+                "name": "not_null_stg_orders_order_id",
+                "column_name": "order_id",
+                "attached_node": model,
+                "depends_on": {"nodes": [model]},
+                "test_metadata": {
+                    "namespace": None,
+                    "name": "not_null",
+                    "kwargs": {"column_name": "order_id"},
+                },
+            },
+            "test.jaffle.assert_totals.def": {
+                "resource_type": "test",
+                "name": "assert_totals",
+                "attached_node": model,
+                "depends_on": {"nodes": [model]},
+                "compiled_code": "select 1",
+            },
+        }
+    }
+
+
+@pytest.fixture
+def manifest_file(tmp_path):
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(_manifest_dict()))
+    return str(path)
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# plan — offline, no auth
+# ══════════════════════════════════════════════════════════════════════════
+
+
+class TestDbtPlan:
+    def test_reports_coverage(self, cli_runner, manifest_file):
+        result = cli_runner.invoke(app, ["dbt", "plan", "--manifest", manifest_file])
+        assert result.exit_code == 0
+        assert "2" in result.output
+        assert "direct" in result.output
+
+    def test_does_not_require_auth(self, cli_runner, manifest_file):
+        """plan must never construct a client."""
+        with patch("qualytics.cli.dbt.get_client") as get_client:
+            result = cli_runner.invoke(
+                app, ["dbt", "plan", "--manifest", manifest_file]
+            )
+        assert result.exit_code == 0
+        get_client.assert_not_called()
+
+    def test_show_checks_lists_rules(self, cli_runner, manifest_file):
+        result = cli_runner.invoke(
+            app, ["dbt", "plan", "--manifest", manifest_file, "--show-checks"]
+        )
+        assert result.exit_code == 0
+        assert "notNull" in result.output
+
+    def test_missing_manifest_errors(self, cli_runner, tmp_path):
+        result = cli_runner.invoke(
+            app, ["dbt", "plan", "--manifest", str(tmp_path / "nope.json")]
+        )
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()
+
+    def test_invalid_json_errors(self, cli_runner, tmp_path):
+        bad = tmp_path / "manifest.json"
+        bad.write_text("{not json")
+        result = cli_runner.invoke(app, ["dbt", "plan", "--manifest", str(bad)])
+        assert result.exit_code == 1
+        assert "json" in result.output.lower()
+
+    def test_json_without_nodes_errors(self, cli_runner, tmp_path):
+        bad = tmp_path / "manifest.json"
+        bad.write_text('{"metadata": {}}')
+        result = cli_runner.invoke(app, ["dbt", "plan", "--manifest", str(bad)])
+        assert result.exit_code == 1
+        assert "nodes" in result.output.lower()
+
+    def test_manifest_with_no_tests_exits_cleanly(self, cli_runner, tmp_path):
+        empty = tmp_path / "manifest.json"
+        empty.write_text(json.dumps({"nodes": {}}))
+        result = cli_runner.invoke(app, ["dbt", "plan", "--manifest", str(empty)])
+        assert result.exit_code == 0
+        assert "nothing to migrate" in result.output.lower()
+
+    def test_bad_container_map_errors(self, cli_runner, manifest_file):
+        result = cli_runner.invoke(
+            app,
+            ["dbt", "plan", "--manifest", manifest_file, "--container-map", "novalue"],
+        )
+        assert result.exit_code == 1
+        assert "model=container" in result.output
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# import — conversion + upsert
+# ══════════════════════════════════════════════════════════════════════════
+
+
+class TestDbtImport:
+    def _run(self, cli_runner, manifest_file, extra=None, result_payload=None):
+        payload = result_payload or {
+            "created": 2,
+            "updated": 0,
+            "failed": 0,
+            "errors": [],
+        }
+        with (
+            patch("qualytics.cli.dbt.get_client", return_value=MagicMock()),
+            patch(
+                "qualytics.cli.dbt.import_checks_to_datastore", return_value=payload
+            ) as importer,
+        ):
+            res = cli_runner.invoke(
+                app,
+                ["dbt", "import", "--manifest", manifest_file, "--datastore-id", "1"]
+                + (extra or []),
+            )
+        return res, importer
+
+    def test_converts_and_imports(self, cli_runner, manifest_file):
+        res, importer = self._run(cli_runner, manifest_file)
+        assert res.exit_code == 0
+        importer.assert_called_once()
+        checks = importer.call_args[0][2]
+        assert len(checks) == 2
+        assert {c["rule_type"] for c in checks} == {"notNull", "satisfiesExpression"}
+
+    def test_passes_dry_run_through(self, cli_runner, manifest_file):
+        res, importer = self._run(cli_runner, manifest_file, ["--dry-run"])
+        assert res.exit_code == 0
+        assert importer.call_args.kwargs["dry_run"] is True
+        assert "DRY RUN" in res.output
+
+    def test_uids_are_dbt_derived(self, cli_runner, manifest_file):
+        _, importer = self._run(cli_runner, manifest_file)
+        for check in importer.call_args[0][2]:
+            assert check["additional_metadata"]["_qualytics_check_uid"].startswith(
+                "dbt__"
+            )
+
+    def test_preserve_status_omits_status(self, cli_runner, manifest_file):
+        _, importer = self._run(cli_runner, manifest_file, ["--preserve-status"])
+        for check in importer.call_args[0][2]:
+            assert "status" not in check
+
+    def test_default_includes_status(self, cli_runner, manifest_file):
+        _, importer = self._run(cli_runner, manifest_file)
+        statuses = {c["status"] for c in importer.call_args[0][2]}
+        assert statuses == {"Active", "Draft"}
+
+    def test_container_map_applied(self, cli_runner, manifest_file):
+        _, importer = self._run(
+            cli_runner, manifest_file, ["--container-map", "stg_orders=ORDERS"]
+        )
+        assert {c["container"] for c in importer.call_args[0][2]} == {"ORDERS"}
+
+    def test_multiple_datastores(self, cli_runner, manifest_file):
+        with (
+            patch("qualytics.cli.dbt.get_client", return_value=MagicMock()),
+            patch(
+                "qualytics.cli.dbt.import_checks_to_datastore",
+                return_value={"created": 2, "updated": 0, "failed": 0, "errors": []},
+            ) as importer,
+        ):
+            res = cli_runner.invoke(
+                app,
+                [
+                    "dbt",
+                    "import",
+                    "--manifest",
+                    manifest_file,
+                    "--datastore-id",
+                    "1",
+                    "--datastore-id",
+                    "2",
+                ],
+            )
+        assert res.exit_code == 0
+        assert importer.call_count == 2
+
+    def test_failures_exit_nonzero_with_guidance(self, cli_runner, manifest_file):
+        res, _ = self._run(
+            cli_runner,
+            manifest_file,
+            result_payload={
+                "created": 0,
+                "updated": 0,
+                "failed": 2,
+                "errors": ["Container 'stg_orders' not found in datastore 1"],
+            },
+        )
+        assert res.exit_code == 1
+        assert "catalogued" in res.output
+
+    def test_emit_yaml_writes_files(self, cli_runner, manifest_file, tmp_path):
+        out = tmp_path / "checks"
+        res, _ = self._run(cli_runner, manifest_file, ["--emit-yaml", str(out)])
+        assert res.exit_code == 0
+
+        files = []
+        for root, _dirs, names in os.walk(out):
+            files += [os.path.join(root, n) for n in names]
+        assert len(files) == 2
+
+        for path in files:
+            with open(path) as f:
+                check = yaml.safe_load(f)
+            assert check["additional_metadata"]["_qualytics_check_uid"].startswith(
+                "dbt__"
+            )
+
+    def test_emit_yaml_filenames_are_unique_per_test(
+        self, cli_runner, manifest_file, tmp_path
+    ):
+        """Two checks on one container must not overwrite each other's file."""
+        out = tmp_path / "checks"
+        self._run(cli_runner, manifest_file, ["--emit-yaml", str(out)])
+        names = [n for _r, _d, ns in os.walk(out) for n in ns]
+        assert len(names) == len(set(names)) == 2

--- a/tests/test_dbt_cli.py
+++ b/tests/test_dbt_cli.py
@@ -175,6 +175,33 @@ class TestDbtImport:
         statuses = {c["status"] for c in importer.call_args[0][2]}
         assert statuses == {"Active", "Draft"}
 
+    def test_status_draft_forces_all_draft(self, cli_runner, manifest_file):
+        res, importer = self._run(cli_runner, manifest_file, ["--status", "Draft"])
+        assert res.exit_code == 0
+        assert {c["status"] for c in importer.call_args[0][2]} == {"Draft"}
+
+    def test_status_active_forces_all_active_and_warns(self, cli_runner, manifest_file):
+        res, importer = self._run(cli_runner, manifest_file, ["--status", "Active"])
+        assert res.exit_code == 0
+        assert {c["status"] for c in importer.call_args[0][2]} == {"Active"}
+        assert "incomplete properties" in res.output
+
+    def test_status_is_case_insensitive(self, cli_runner, manifest_file):
+        _, importer = self._run(cli_runner, manifest_file, ["--status", "draft"])
+        assert {c["status"] for c in importer.call_args[0][2]} == {"Draft"}
+
+    def test_invalid_status_errors(self, cli_runner, manifest_file):
+        res, _ = self._run(cli_runner, manifest_file, ["--status", "Paused"])
+        assert res.exit_code == 1
+        assert "Active or Draft" in res.output
+
+    def test_status_conflicts_with_preserve_status(self, cli_runner, manifest_file):
+        res, _ = self._run(
+            cli_runner, manifest_file, ["--status", "Draft", "--preserve-status"]
+        )
+        assert res.exit_code == 1
+        assert "mutually exclusive" in res.output
+
     def test_container_map_applied(self, cli_runner, manifest_file):
         _, importer = self._run(
             cli_runner, manifest_file, ["--container-map", "stg_orders=ORDERS"]

--- a/tests/test_dbt_cli.py
+++ b/tests/test_dbt_cli.py
@@ -353,3 +353,95 @@ class TestFieldValidation:
         assert ["order_id"] in [
             c["fields"] for c in importer.call_args[0][2] if c["fields"]
         ]
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# --emit-yaml must stay inside the directory the caller chose
+# ══════════════════════════════════════════════════════════════════════════
+
+
+class TestEmitYamlContainment:
+    def _manifest_with_alias(self, tmp_path, alias):
+        model = "model.jaffle.stg_orders"
+        manifest = {
+            "nodes": {
+                model: {
+                    "resource_type": "model",
+                    "name": "stg_orders",
+                    "alias": alias,
+                },
+                "test.jaffle.not_null_stg_orders_order_id.abc": {
+                    "resource_type": "test",
+                    "name": "nn",
+                    "column_name": "order_id",
+                    "attached_node": model,
+                    "depends_on": {"nodes": [model]},
+                    "test_metadata": {
+                        "namespace": None,
+                        "name": "not_null",
+                        "kwargs": {"column_name": "order_id"},
+                    },
+                },
+            }
+        }
+        path = tmp_path / "manifest.json"
+        path.write_text(json.dumps(manifest))
+        return str(path)
+
+    def _emit(self, cli_runner, manifest_file, out_dir):
+        with (
+            patch("qualytics.cli.dbt.get_client", return_value=MagicMock()),
+            patch(
+                "qualytics.cli.dbt.import_checks_to_datastore",
+                return_value={"created": 1, "updated": 0, "failed": 0, "errors": []},
+            ),
+        ):
+            return cli_runner.invoke(
+                app,
+                [
+                    "dbt",
+                    "import",
+                    "--manifest",
+                    manifest_file,
+                    "--datastore-id",
+                    "1",
+                    "--emit-yaml",
+                    str(out_dir),
+                    "--no-validate-fields",
+                ],
+            )
+
+    def _written(self, out_dir):
+        return [os.path.join(r, n) for r, _d, ns in os.walk(out_dir) for n in ns]
+
+    def test_traversal_alias_stays_inside_output_dir(self, cli_runner, tmp_path):
+        """A manifest is often someone else's file; its alias is untrusted."""
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        out_dir = tmp_path / "checks"
+        mf = self._manifest_with_alias(tmp_path, "../outside/pwned")
+
+        res = self._emit(cli_runner, mf, out_dir)
+        assert res.exit_code == 0
+        assert not self._written(outside), "wrote outside the chosen directory"
+        assert len(self._written(out_dir)) == 1
+
+    def test_absolute_alias_stays_inside_output_dir(self, cli_runner, tmp_path):
+        outside = tmp_path / "abs"
+        outside.mkdir()
+        out_dir = tmp_path / "checks"
+        mf = self._manifest_with_alias(tmp_path, f"{outside}/pwned")
+
+        res = self._emit(cli_runner, mf, out_dir)
+        assert res.exit_code == 0
+        assert not self._written(outside)
+        assert len(self._written(out_dir)) == 1
+
+    def test_normal_alias_still_groups_by_container(self, cli_runner, tmp_path):
+        out_dir = tmp_path / "checks"
+        mf = self._manifest_with_alias(tmp_path, "stg_orders")
+        res = self._emit(cli_runner, mf, out_dir)
+        assert res.exit_code == 0
+        written = self._written(out_dir)
+        assert len(written) == 1
+        assert os.path.basename(os.path.dirname(written[0])) == "stg_orders"


### PR DESCRIPTION
Adds a `dbt` command group that converts a compiled dbt `manifest.json` into Qualytics quality checks and imports them, reusing the existing upsert path.

```bash
qualytics dbt plan   --manifest target/manifest.json [--show-checks]
qualytics dbt import --manifest target/manifest.json --datastore-id 42 [--dry-run]
```

`plan` is offline and never constructs an API client. `import` converts in memory and hands the checks straight to `import_checks_to_datastore`, so upsert, dry-run, multi-datastore targeting and per-check error reporting are inherited rather than reimplemented.

## Design

**`services/dbt.py` is pure** — no client, no auth, no network. That keeps the mapping fully unit-testable and lets `plan` run in CI without credentials.

**Every UID is distinct.** The check UID derives from each dbt node's `unique_id`, plus a rule-type suffix for tests that split into two checks. It deliberately does *not* reuse `generate_check_uid`, whose `container__rule__fields` scheme collides for cases dbt produces routinely — several singular tests on one model, two `expression_is_true` on one column. The importer upserts on UID match, so a collision would silently overwrite a check rather than error.

**Nothing is dropped.** Unrecognized generic tests and singular SQL tests still emit a check, as `satisfiesExpression` in `Draft` with the dbt source in `additional_metadata`. Tiers grade effort, not feasibility: `direct` lands Active, `normalize` and `manual` land Draft. `--status` overrides that wholesale in either direction — the migration is the user's to manage.

**Rule contracts are read from controlplane**, not assumed. `RULE_CONTRACT` encodes fields cardinality, `filterable` and `supports_coverage` per rule, because they are not uniform: `volumetric` and `freshness` are container-level and reject a filter, and several rules do not support coverage.

## What carries across

- `config.where` → check `filter` (correctness: dropping it runs the check against exactly the rows dbt excluded)
- Properties built from kwargs — `distinctCount` comparison+value, `freshness` in milliseconds, `expectedSchema`, `existsIn.field_name`, `between` inclusivity flags
- Length ranges split into `minLength` + `maxLength`
- Everything unmapped recorded in `additional_metadata` (`dbt_kwargs`, severity, tags, package, compiled SQL) so completing a Draft never means reopening the dbt project

## Field validation

Field names are resolved against `/containers/{id}/fields` before import. The importer resolves container names to IDs and errors on a miss, but passes `fields` through untouched — so a field absent from the warehouse created a check that never evaluates, silently. Because the catalogue is ground truth this also corrects casing (dbt writes `order_id`, Snowflake catalogues `ORDER_ID`) rather than needing a `--field-case` flag. `--no-validate-fields` disables it.

Implements `qualytics/api/fields.py`, previously an empty placeholder, and registers the endpoint in the API compatibility manifest.

## Testing

878 tests pass (152 new across `tests/test_dbt.py` and `tests/test_dbt_cli.py`), ruff clean and formatted. Verified end-to-end against a real manifest: 28 dbt tests → 29 checks, 90% mapped automatically, all containers resolved.

## Not yet validated — why this is a draft

Every rule identifier, property name and rule contract was verified by reading controlplane source, but **nothing has been exercised against a live instance**. `--dry-run` will not catch a bad payload because it skips the create call entirely. A real import against a dev datastore is the only thing that will, and it may move some checks between tiers.

One deliberate assumption to review: `volumetric` is percentage-drift oriented and requires a moving-average `window_size` that dbt has no concept of. dbt's `expect_table_row_count_to_be_between` is an absolute range, so it maps with `comparison: "Absolute Value"` and `window_size: 1`, and stays Draft so the window is confirmed rather than silently assumed. It is the only invented value in the mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)